### PR TITLE
Format code according to `rustfmt` best practices

### DIFF
--- a/src/color_parsing.rs
+++ b/src/color_parsing.rs
@@ -7,12 +7,10 @@
 // assumed to be 255.
 // This is not properly formatted for rustdoc because it doesn't fit within a larger framework yet.
 
-
 use std::result::Result::Err;
 use std::collections::HashMap;
 extern crate regex;
 use self::regex::Regex;
-
 
 #[derive(Debug)]
 enum ColorParseError {
@@ -21,28 +19,32 @@ enum ColorParseError {
     OutOfRangeRGBA,
     OutOfRangeHSLA,
     InvalidHSLAFunction,
-    InvalidX11Name
+    InvalidX11Name,
 }
 
 fn hex_to_rgba(hex: &str) -> Result<Vec<u8>, ColorParseError> {
     // Parse for valid hex: has to be of the form #rrggbb or #rrggbbaa, where the values after the
     // # have to be valid hex (0-9, a-f, or A-F)
     if hex.chars().nth(0) != Some('#') {
-        return Err(ColorParseError::InvalidHTMLHex)
-    }; 
-    let count = hex.chars().count(); 
+        return Err(ColorParseError::InvalidHTMLHex);
+    };
+    let count = hex.chars().count();
     if ![7, 9].contains(&count) {
         Err(ColorParseError::InvalidHTMLHex)
-    } else if hex.chars().skip(1).any(|x| !("abcdefABCDEF0123456789".contains(x))) {
+    } else if hex.chars()
+        .skip(1)
+        .any(|x| !("abcdefABCDEF0123456789".contains(x)))
+    {
         Err(ColorParseError::InvalidHTMLHex)
-    } else { // valid hex: return useful value
+    } else {
+        // valid hex: return useful value
         // it's easier to do math on the hex value than it is to slice strings
-        let mut full_num:u32 = u32::from_str_radix(hex.chars().skip(1).collect::<String>().as_str(), 16).unwrap();
-        let mut a:u8 = 255;
+        let mut full_num: u32 =
+            u32::from_str_radix(hex.chars().skip(1).collect::<String>().as_str(), 16).unwrap();
+        let mut a: u8 = 255;
         if count == 7 {
             // no need to do anything, alpha is already set
-        }
-        else {
+        } else {
             // alpha is the number modulo 16^2, divide the number by 16^2 to remove the alpha
             // component afterwards
             // this should become bit operations that are really fast, but I haven't checked it to
@@ -66,7 +68,7 @@ fn hex_to_rgba(hex: &str) -> Result<Vec<u8>, ColorParseError> {
 fn func_to_rgba(input: &str) -> Result<Vec<u8>, ColorParseError> {
     // test for any characters that are not spaces, parentheses, commas,  the letters rgba, or digits
     if !(input.chars().all(|c| " ()rgba0123456789,".contains(c))) {
-        return Err(ColorParseError::InvalidRGBAFunction)
+        return Err(ColorParseError::InvalidRGBAFunction);
     };
     // now we don't have to worry about indexing issues, as everything is ASCII
     // to simplify the string processing from here on out, we'll use regexes
@@ -75,28 +77,29 @@ fn func_to_rgba(input: &str) -> Result<Vec<u8>, ColorParseError> {
     // code it would take to accomplish that and the increased error likelihood
     // it's also a bit on the read-only side! testing is crucial here
     // note that this does not verify that the numbers are in bounds, just that they're between 0 and 999
-    let rgba_re = Regex::new(r"rgba\((?: *(\d{1,3}),)(?: *(\d{1,3}),)(?: *(\d{1,3}),)(?: *(\d{1,3}))\)").unwrap();
+    let rgba_re = Regex::new(
+        r"rgba\((?: *(\d{1,3}),)(?: *(\d{1,3}),)(?: *(\d{1,3}),)(?: *(\d{1,3}))\)",
+    ).unwrap();
     let rgb_re = Regex::new(r"rgb\((?: *(\d{1,3}),)(?: *(\d{1,3}),)(?: *(\d{1,3}))\)").unwrap();
-   
+
     // try matching each one, falling back to rgb if rgba fails
     let grps = match rgba_re.captures(input) {
         None => rgb_re.captures(input),
-        x @ Some(_) => x
+        x @ Some(_) => x,
     };
     // now either return an error, process an RGBA string list, or an RGB string list
     match grps {
         None => Err(ColorParseError::InvalidRGBAFunction),
         Some(ref x) if x.len() == 4 => {
             let (rstr, gstr, bstr) = (&x[1], &x[2], &x[3]);
-            let a:u8 = 255;
+            let a: u8 = 255;
             // use u16s so that values > 255 will be detected
             let r = u16::from_str_radix(rstr, 10).unwrap();
             let g = u16::from_str_radix(gstr, 10).unwrap();
             let b = u16::from_str_radix(bstr, 10).unwrap();
             if (r > 255) | (g > 255) | (b > 255) {
                 Err(ColorParseError::OutOfRangeRGBA)
-            }
-            else {
+            } else {
                 Ok(vec![r as u8, g as u8, b as u8, a])
             }
         }
@@ -108,66 +111,322 @@ fn func_to_rgba(input: &str) -> Result<Vec<u8>, ColorParseError> {
             let a = u16::from_str_radix(astr, 10).unwrap();
             if (r > 255) | (g > 255) | (b > 255) | (a > 255) {
                 Err(ColorParseError::OutOfRangeRGBA)
-            }
-            else {
+            } else {
                 Ok(vec![r as u8, g as u8, b as u8, a as u8])
             }
-        },
-        Some(_) => Err(ColorParseError::InvalidRGBAFunction)
+        }
+        Some(_) => Err(ColorParseError::InvalidRGBAFunction),
     }
 }
 
-// Takes in an X11 color name, like "blue", and returns the corresponding 
+// Takes in an X11 color name, like "blue", and returns the corresponding
 // RGB values as a vector [r, g, b, a] where a is 255.
 fn name_to_rgba(name: &str) -> Result<Vec<u8>, ColorParseError> {
     // this is the full list of X11 color names
     // I used a Python script to process it from this site:
     // https://github.com/bahamas10/css-color-names/blob/master/css-color-names.json let
     // I added the special "transparent" referring to #00000000
-    let color_names:Vec<&str> = [
-        "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige",
-        "bisque", "black", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue",
-        "chartreuse", "chocolate", "coral", "cornflowerblue", "cornsilk", "crimson", "cyan", "darkblue",
-        "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkgrey", "darkkhaki", "darkmagenta",
-        "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon", "darkseagreen",
-        "darkslateblue", "darkslategray", "darkslategrey", "darkturquoise", "darkviolet", "deeppink",
-        "deepskyblue", "dimgray", "dimgrey", "dodgerblue", "firebrick", "floralwhite", "forestgreen",
-        "fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "green", "greenyellow",
-        "grey", "honeydew", "hotpink", "indianred", "indigo", "ivory", "khaki", "lavender",
-        "lavenderblush", "lawngreen", "lemonchiffon", "lightblue", "lightcoral", "lightcyan",
-        "lightgoldenrodyellow", "lightgray", "lightgreen", "lightgrey", "lightpink", "lightsalmon",
-        "lightseagreen", "lightskyblue", "lightslategray", "lightslategrey", "lightsteelblue",
-        "lightyellow", "lime", "limegreen", "linen", "magenta", "maroon", "mediumaquamarine",
-        "mediumblue", "mediumorchid", "mediumpurple", "mediumseagreen", "mediumslateblue",
-        "mediumspringgreen", "mediumturquoise", "mediumvioletred", "midnightblue", "mintcream",
-        "mistyrose", "moccasin", "navajowhite", "navy", "oldlace", "olive", "olivedrab", "orange",
-        "orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise", "palevioletred",
-        "papayawhip", "peachpuff", "peru", "pink", "plum", "powderblue", "purple", "rebeccapurple",
-        "red", "rosybrown", "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell",
-        "sienna", "silver", "skyblue", "slateblue", "slategray", "slategrey", "snow", "springgreen",
-        "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white",
-        "whitesmoke", "yellow", "yellowgreen", "transparent"
+    let color_names: Vec<&str> = [
+        "aliceblue",
+        "antiquewhite",
+        "aqua",
+        "aquamarine",
+        "azure",
+        "beige",
+        "bisque",
+        "black",
+        "blanchedalmond",
+        "blue",
+        "blueviolet",
+        "brown",
+        "burlywood",
+        "cadetblue",
+        "chartreuse",
+        "chocolate",
+        "coral",
+        "cornflowerblue",
+        "cornsilk",
+        "crimson",
+        "cyan",
+        "darkblue",
+        "darkcyan",
+        "darkgoldenrod",
+        "darkgray",
+        "darkgreen",
+        "darkgrey",
+        "darkkhaki",
+        "darkmagenta",
+        "darkolivegreen",
+        "darkorange",
+        "darkorchid",
+        "darkred",
+        "darksalmon",
+        "darkseagreen",
+        "darkslateblue",
+        "darkslategray",
+        "darkslategrey",
+        "darkturquoise",
+        "darkviolet",
+        "deeppink",
+        "deepskyblue",
+        "dimgray",
+        "dimgrey",
+        "dodgerblue",
+        "firebrick",
+        "floralwhite",
+        "forestgreen",
+        "fuchsia",
+        "gainsboro",
+        "ghostwhite",
+        "gold",
+        "goldenrod",
+        "gray",
+        "green",
+        "greenyellow",
+        "grey",
+        "honeydew",
+        "hotpink",
+        "indianred",
+        "indigo",
+        "ivory",
+        "khaki",
+        "lavender",
+        "lavenderblush",
+        "lawngreen",
+        "lemonchiffon",
+        "lightblue",
+        "lightcoral",
+        "lightcyan",
+        "lightgoldenrodyellow",
+        "lightgray",
+        "lightgreen",
+        "lightgrey",
+        "lightpink",
+        "lightsalmon",
+        "lightseagreen",
+        "lightskyblue",
+        "lightslategray",
+        "lightslategrey",
+        "lightsteelblue",
+        "lightyellow",
+        "lime",
+        "limegreen",
+        "linen",
+        "magenta",
+        "maroon",
+        "mediumaquamarine",
+        "mediumblue",
+        "mediumorchid",
+        "mediumpurple",
+        "mediumseagreen",
+        "mediumslateblue",
+        "mediumspringgreen",
+        "mediumturquoise",
+        "mediumvioletred",
+        "midnightblue",
+        "mintcream",
+        "mistyrose",
+        "moccasin",
+        "navajowhite",
+        "navy",
+        "oldlace",
+        "olive",
+        "olivedrab",
+        "orange",
+        "orangered",
+        "orchid",
+        "palegoldenrod",
+        "palegreen",
+        "paleturquoise",
+        "palevioletred",
+        "papayawhip",
+        "peachpuff",
+        "peru",
+        "pink",
+        "plum",
+        "powderblue",
+        "purple",
+        "rebeccapurple",
+        "red",
+        "rosybrown",
+        "royalblue",
+        "saddlebrown",
+        "salmon",
+        "sandybrown",
+        "seagreen",
+        "seashell",
+        "sienna",
+        "silver",
+        "skyblue",
+        "slateblue",
+        "slategray",
+        "slategrey",
+        "snow",
+        "springgreen",
+        "steelblue",
+        "tan",
+        "teal",
+        "thistle",
+        "tomato",
+        "turquoise",
+        "violet",
+        "wheat",
+        "white",
+        "whitesmoke",
+        "yellow",
+        "yellowgreen",
+        "transparent",
     ].to_vec();
-    let color_codes:Vec<&str> = [
-        "#f0f8ff", "#faebd7", "#00ffff", "#7fffd4", "#f0ffff", "#f5f5dc", "#ffe4c4", "#000000",
-        "#ffebcd", "#0000ff", "#8a2be2", "#a52a2a", "#deb887", "#5f9ea0", "#7fff00", "#d2691e",
-        "#ff7f50", "#6495ed", "#fff8dc", "#dc143c", "#00ffff", "#00008b", "#008b8b", "#b8860b",
-        "#a9a9a9", "#006400", "#a9a9a9", "#bdb76b", "#8b008b", "#556b2f", "#ff8c00", "#9932cc",
-        "#8b0000", "#e9967a", "#8fbc8f", "#483d8b", "#2f4f4f", "#2f4f4f", "#00ced1", "#9400d3",
-        "#ff1493", "#00bfff", "#696969", "#696969", "#1e90ff", "#b22222", "#fffaf0", "#228b22",
-        "#ff00ff", "#dcdcdc", "#f8f8ff", "#ffd700", "#daa520", "#808080", "#008000", "#adff2f",
-        "#808080", "#f0fff0", "#ff69b4", "#cd5c5c", "#4b0082", "#fffff0", "#f0e68c", "#e6e6fa",
-        "#fff0f5", "#7cfc00", "#fffacd", "#add8e6", "#f08080", "#e0ffff", "#fafad2", "#d3d3d3",
-        "#90ee90", "#d3d3d3", "#ffb6c1", "#ffa07a", "#20b2aa", "#87cefa", "#778899", "#778899",
-        "#b0c4de", "#ffffe0", "#00ff00", "#32cd32", "#faf0e6", "#ff00ff", "#800000", "#66cdaa",
-        "#0000cd", "#ba55d3", "#9370db", "#3cb371", "#7b68ee", "#00fa9a", "#48d1cc", "#c71585",
-        "#191970", "#f5fffa", "#ffe4e1", "#ffe4b5", "#ffdead", "#000080", "#fdf5e6", "#808000",
-        "#6b8e23", "#ffa500", "#ff4500", "#da70d6", "#eee8aa", "#98fb98", "#afeeee", "#db7093",
-        "#ffefd5", "#ffdab9", "#cd853f", "#ffc0cb", "#dda0dd", "#b0e0e6", "#800080", "#663399",
-        "#ff0000", "#bc8f8f", "#4169e1", "#8b4513", "#fa8072", "#f4a460", "#2e8b57", "#fff5ee",
-        "#a0522d", "#c0c0c0", "#87ceeb", "#6a5acd", "#708090", "#708090", "#fffafa", "#00ff7f",
-        "#4682b4", "#d2b48c", "#008080", "#d8bfd8", "#ff6347", "#40e0d0", "#ee82ee", "#f5deb3",
-        "#ffffff", "#f5f5f5", "#ffff00", "#9acd32", "#00000000"
+    let color_codes: Vec<&str> = [
+        "#f0f8ff",
+        "#faebd7",
+        "#00ffff",
+        "#7fffd4",
+        "#f0ffff",
+        "#f5f5dc",
+        "#ffe4c4",
+        "#000000",
+        "#ffebcd",
+        "#0000ff",
+        "#8a2be2",
+        "#a52a2a",
+        "#deb887",
+        "#5f9ea0",
+        "#7fff00",
+        "#d2691e",
+        "#ff7f50",
+        "#6495ed",
+        "#fff8dc",
+        "#dc143c",
+        "#00ffff",
+        "#00008b",
+        "#008b8b",
+        "#b8860b",
+        "#a9a9a9",
+        "#006400",
+        "#a9a9a9",
+        "#bdb76b",
+        "#8b008b",
+        "#556b2f",
+        "#ff8c00",
+        "#9932cc",
+        "#8b0000",
+        "#e9967a",
+        "#8fbc8f",
+        "#483d8b",
+        "#2f4f4f",
+        "#2f4f4f",
+        "#00ced1",
+        "#9400d3",
+        "#ff1493",
+        "#00bfff",
+        "#696969",
+        "#696969",
+        "#1e90ff",
+        "#b22222",
+        "#fffaf0",
+        "#228b22",
+        "#ff00ff",
+        "#dcdcdc",
+        "#f8f8ff",
+        "#ffd700",
+        "#daa520",
+        "#808080",
+        "#008000",
+        "#adff2f",
+        "#808080",
+        "#f0fff0",
+        "#ff69b4",
+        "#cd5c5c",
+        "#4b0082",
+        "#fffff0",
+        "#f0e68c",
+        "#e6e6fa",
+        "#fff0f5",
+        "#7cfc00",
+        "#fffacd",
+        "#add8e6",
+        "#f08080",
+        "#e0ffff",
+        "#fafad2",
+        "#d3d3d3",
+        "#90ee90",
+        "#d3d3d3",
+        "#ffb6c1",
+        "#ffa07a",
+        "#20b2aa",
+        "#87cefa",
+        "#778899",
+        "#778899",
+        "#b0c4de",
+        "#ffffe0",
+        "#00ff00",
+        "#32cd32",
+        "#faf0e6",
+        "#ff00ff",
+        "#800000",
+        "#66cdaa",
+        "#0000cd",
+        "#ba55d3",
+        "#9370db",
+        "#3cb371",
+        "#7b68ee",
+        "#00fa9a",
+        "#48d1cc",
+        "#c71585",
+        "#191970",
+        "#f5fffa",
+        "#ffe4e1",
+        "#ffe4b5",
+        "#ffdead",
+        "#000080",
+        "#fdf5e6",
+        "#808000",
+        "#6b8e23",
+        "#ffa500",
+        "#ff4500",
+        "#da70d6",
+        "#eee8aa",
+        "#98fb98",
+        "#afeeee",
+        "#db7093",
+        "#ffefd5",
+        "#ffdab9",
+        "#cd853f",
+        "#ffc0cb",
+        "#dda0dd",
+        "#b0e0e6",
+        "#800080",
+        "#663399",
+        "#ff0000",
+        "#bc8f8f",
+        "#4169e1",
+        "#8b4513",
+        "#fa8072",
+        "#f4a460",
+        "#2e8b57",
+        "#fff5ee",
+        "#a0522d",
+        "#c0c0c0",
+        "#87ceeb",
+        "#6a5acd",
+        "#708090",
+        "#708090",
+        "#fffafa",
+        "#00ff7f",
+        "#4682b4",
+        "#d2b48c",
+        "#008080",
+        "#d8bfd8",
+        "#ff6347",
+        "#40e0d0",
+        "#ee82ee",
+        "#f5deb3",
+        "#ffffff",
+        "#f5f5f5",
+        "#ffff00",
+        "#9acd32",
+        "#00000000",
     ].to_vec();
     let mut names_to_codes = HashMap::new();
 
@@ -178,7 +437,6 @@ fn name_to_rgba(name: &str) -> Result<Vec<u8>, ColorParseError> {
     // now just return the converted value or raise one if not in hashmap
     match names_to_codes.get(&name) {
         None => Err(ColorParseError::InvalidX11Name),
-        Some(x) => hex_to_rgba(x)
+        Some(x) => hex_to_rgba(x),
     }
 }
-

--- a/src/colors/adobergbcolor.rs
+++ b/src/colors/adobergbcolor.rs
@@ -33,21 +33,17 @@ impl Color for AdobeRGBColor {
         let clamp = |x: f64| {
             if x > 1.0 {
                 1.0
-            }
-            else if x < 0.0 {
+            } else if x < 0.0 {
                 0.0
-            }
-            else {
+            } else {
                 x
             }
         };
-        
-        // now we apply gamma transformation
-        let gamma = |x: f64| {
-            x.powf(256.0 / 563.0)
-        };
 
-        AdobeRGBColor{
+        // now we apply gamma transformation
+        let gamma = |x: f64| x.powf(256.0 / 563.0);
+
+        AdobeRGBColor {
             r: gamma(clamp(rgb[0])),
             g: gamma(clamp(rgb[1])),
             b: gamma(clamp(rgb[2])),
@@ -56,22 +52,17 @@ impl Color for AdobeRGBColor {
     /// Converts from Adobe RGB to an XYZ color in a given illuminant (via chromatic adaptation).
     fn to_xyz(&self, illuminant: Illuminant) -> XYZColor {
         // undo gamma transformation
-        let ungamma = |x: f64| {
-            x.powf(563.0 / 256.0)
-        };
+        let ungamma = |x: f64| x.powf(563.0 / 256.0);
 
         // inverse matrix to the one in from_xyz
-        let xyz_vec = consts::inv(ADOBE_RGB()) * Vector3::new(
-            ungamma(self.r),
-            ungamma(self.g),
-            ungamma(self.b)
-        );
+        let xyz_vec = consts::inv(ADOBE_RGB())
+            * Vector3::new(ungamma(self.r), ungamma(self.g), ungamma(self.b));
 
-        XYZColor{
+        XYZColor {
             x: xyz_vec[0],
             y: xyz_vec[1],
             z: xyz_vec[2],
-            illuminant: Illuminant::D65
+            illuminant: Illuminant::D65,
         }.color_adapt(illuminant)
     }
 }
@@ -83,21 +74,27 @@ impl From<Coord> for AdobeRGBColor {
         let clamp = |x: f64| {
             if x <= 0.0 {
                 0.0
-            }
-            else if x >= 1.0 {
+            } else if x >= 1.0 {
                 1.0
-            }
-            else {
+            } else {
                 x
             }
         };
-        AdobeRGBColor{r: clamp(c.x), g: clamp(c.y), b: clamp(c.z)}
+        AdobeRGBColor {
+            r: clamp(c.x),
+            g: clamp(c.y),
+            b: clamp(c.z),
+        }
     }
 }
 
 impl Into<Coord> for AdobeRGBColor {
     fn into(self) -> Coord {
-        Coord{x: self.r, y: self.g, z: self.b}
+        Coord {
+            x: self.r,
+            y: self.g,
+            z: self.b,
+        }
     }
 }
 
@@ -109,25 +106,49 @@ mod tests {
 
     #[test]
     fn test_adobe_rgb_xyz_conversion() {
-        let xyz1 = XYZColor{x: 0.4, y: 0.2, z: 0.5, illuminant: Illuminant::D75};
+        let xyz1 = XYZColor {
+            x: 0.4,
+            y: 0.2,
+            z: 0.5,
+            illuminant: Illuminant::D75,
+        };
         let xyz2 = AdobeRGBColor::from_xyz(xyz1).to_xyz(Illuminant::D75);
         assert!(xyz1.approx_equal(&xyz2));
     }
     #[test]
     fn test_adobe_rgb_clamping() {
-        let argb = AdobeRGBColor{r: 1.1, g: 0.6, b: 0.8};
-        let argb2 = AdobeRGBColor{r: 1.0, g: 0.6, b: 0.8};
+        let argb = AdobeRGBColor {
+            r: 1.1,
+            g: 0.6,
+            b: 0.8,
+        };
+        let argb2 = AdobeRGBColor {
+            r: 1.0,
+            g: 0.6,
+            b: 0.8,
+        };
         let argbprime = argb.convert::<XYZColor>().convert::<AdobeRGBColor>();
         let argb2prime = argb2.convert::<XYZColor>().convert::<AdobeRGBColor>();
         let xyz1 = argbprime.to_xyz(Illuminant::D50);
         let xyz2 = argb2prime.to_xyz(Illuminant::D50);
-        println!("{} {} {} {} {} {}", xyz1.x, xyz2.x, xyz1.y, xyz2.y, xyz1.z, xyz2.z);
+        println!(
+            "{} {} {} {} {} {}",
+            xyz1.x, xyz2.x, xyz1.y, xyz2.y, xyz1.z, xyz2.z
+        );
         assert!(xyz1.approx_equal(&xyz2));
     }
     #[test]
     fn test_adobe_rgb_mixing() {
-        let argb = AdobeRGBColor{r: 0.4, g: 0.2, b: 0.5};
-        let argb2 = AdobeRGBColor{r: 0.6, g: 0.6, b: 0.8};
+        let argb = AdobeRGBColor {
+            r: 0.4,
+            g: 0.2,
+            b: 0.5,
+        };
+        let argb2 = AdobeRGBColor {
+            r: 0.6,
+            g: 0.6,
+            b: 0.8,
+        };
         let argb_mixed = argb.mix(argb2);
         assert!((argb_mixed.r - 0.5).abs() <= 1e-7);
         assert!((argb_mixed.g - 0.4).abs() <= 1e-7);

--- a/src/colors/cielabcolor.rs
+++ b/src/colors/cielabcolor.rs
@@ -10,8 +10,6 @@ use color::{Color, XYZColor};
 use coord::Coord;
 use illuminants::Illuminant;
 
-
-
 /// A color in the CIELAB color space.
 #[derive(Debug, Copy, Clone)]
 pub struct CIELABColor {
@@ -45,17 +43,18 @@ impl Color for CIELABColor {
             let delta: f64 = 6.0 / 29.0;
             if *x <= delta.powf(3.0) {
                 x / (3.0 * delta * delta) + 4.0 / 29.0
-            }
-            else {
+            } else {
                 x.powf(1.0 / 3.0)
             }
         };
         // now get the XYZ coordinates normalized using D50: convert to that beforehand if not
         let white_point = Illuminant::D50.white_point();
         let xyz_adapted = xyz.color_adapt(Illuminant::D50);
-        let xyz_scaled = [xyz_adapted.x / white_point[0],
-                          xyz_adapted.y / white_point[1],
-                          xyz_adapted.z / white_point[2]];
+        let xyz_scaled = [
+            xyz_adapted.x / white_point[0],
+            xyz_adapted.y / white_point[1],
+            xyz_adapted.z / white_point[2],
+        ];
         let xyz_transformed: Vec<f64> = xyz_scaled.iter().map(f).collect();
 
         // xyz_transformed was modified to allow for human nonlinearity of color vision
@@ -64,7 +63,7 @@ impl Color for CIELABColor {
         let l = 116.0 * xyz_transformed[1] - 16.0;
         let a = 500.0 * (xyz_transformed[0] - xyz_transformed[1]);
         let b = 200.0 * (xyz_transformed[1] - xyz_transformed[2]);
-        CIELABColor{l, a, b}
+        CIELABColor { l, a, b }
     }
     /// Returns an XYZ color that corresponds to the CIELAB color. Note that, because implicitly every
     /// CIELAB color is D50, conversion is done by first converting to a D50 XYZ color and then using
@@ -76,8 +75,7 @@ impl Color for CIELABColor {
             let delta: f64 = 6.0 / 29.0;
             if x > delta {
                 x * x * x
-            }
-            else {
+            } else {
                 3.0 * delta * delta * (x - 4.0 / 29.0)
             }
         };
@@ -87,22 +85,34 @@ impl Color for CIELABColor {
         let y = xyz_n[1] * f_inv((self.l + 16.0) / 116.0);
         let z = xyz_n[2] * f_inv((self.l + 16.0) / 116.0 - (self.b / 200.0));
         // this is CIELAB D50, so to use custom illuminant do chromatic adaptation
-        XYZColor{x, y, z, illuminant: Illuminant::D50}.color_adapt(illuminant)
+        XYZColor {
+            x,
+            y,
+            z,
+            illuminant: Illuminant::D50,
+        }.color_adapt(illuminant)
     }
 }
 
 impl From<Coord> for CIELABColor {
     fn from(c: Coord) -> CIELABColor {
-        CIELABColor{l: c.x, a: c.y, b: c.z}
+        CIELABColor {
+            l: c.x,
+            a: c.y,
+            b: c.z,
+        }
     }
 }
 
 impl Into<Coord> for CIELABColor {
     fn into(self) -> Coord {
-        Coord{x: self.l, y: self.a, z: self.b}
+        Coord {
+            x: self.l,
+            y: self.a,
+            z: self.b,
+        }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -111,14 +121,24 @@ mod tests {
     use color::{Mix, RGBColor};
     #[test]
     fn test_cielab_xyz_conversion_d50() {
-        let xyz = XYZColor{x: 0.4, y: 0.2, z: 0.6, illuminant: Illuminant::D50};
+        let xyz = XYZColor {
+            x: 0.4,
+            y: 0.2,
+            z: 0.6,
+            illuminant: Illuminant::D50,
+        };
         let lab = CIELABColor::from_xyz(xyz);
         let xyz2 = lab.to_xyz(Illuminant::D50);
         assert!(xyz.approx_equal(&xyz2));
     }
     #[test]
     fn test_cielab_xyz_conversion() {
-        let xyz = XYZColor{x: 0.4, y: 0.2, z: 0.6, illuminant: Illuminant::D65};
+        let xyz = XYZColor {
+            x: 0.4,
+            y: 0.2,
+            z: 0.6,
+            illuminant: Illuminant::D65,
+        };
         let lab = CIELABColor::from_xyz(xyz);
         let xyz_d50 = lab.to_xyz(Illuminant::D50);
         let xyz2 = xyz_d50.color_adapt(Illuminant::D65);
@@ -126,8 +146,16 @@ mod tests {
     }
     #[test]
     fn test_cielab_color_mixing() {
-        let lab = CIELABColor{l: 50.0, a: -45.0, b: 65.0};
-        let lab2 = CIELABColor{l: 60.0, a: -25.0, b: 75.0};
+        let lab = CIELABColor {
+            l: 50.0,
+            a: -45.0,
+            b: 65.0,
+        };
+        let lab2 = CIELABColor {
+            l: 60.0,
+            a: -25.0,
+            b: 75.0,
+        };
         let lab_mixed = lab.mix(lab2);
         assert!((lab_mixed.l - 55.0).abs() <= 1e-7);
         assert!((lab_mixed.a + 35.0).abs() <= 1e-7);
@@ -136,7 +164,11 @@ mod tests {
     #[test]
     fn test_out_of_gamut() {
         // this color doesn't exist in sRGB! (that's probably a good thing, this can't really be represented)
-        let color1 = CIELABColor{l: 0.0, a: 100.0, b: 100.0};
+        let color1 = CIELABColor {
+            l: 0.0,
+            a: 100.0,
+            b: 100.0,
+        };
         let color2: RGBColor = color1.convert();
         println!("{}", color2.to_string());
         let color3: CIELABColor = color2.convert();

--- a/src/colors/cielchcolor.rs
+++ b/src/colors/cielchcolor.rs
@@ -32,11 +32,11 @@ impl Color for CIELCHColor {
     fn from_xyz(xyz: XYZColor) -> CIELCHColor {
         // first get LAB coordinates
         let lab = CIELABColor::from_xyz(xyz);
-        let l = lab.l;  // the same in both spaces
-        // now we have to do some math
-        // radius is sqrt(a^2 + b^2)
-        // angle is atan2(a, b)
-        // Rust does this ez
+        let l = lab.l; // the same in both spaces
+                       // now we have to do some math
+                       // radius is sqrt(a^2 + b^2)
+                       // angle is atan2(a, b)
+                       // Rust does this ez
         let c = lab.b.hypot(lab.a);
         // don't forget to convert to degrees
         let unbounded_h = lab.b.atan2(lab.a).to_degrees();
@@ -49,8 +49,8 @@ impl Color for CIELCHColor {
         } else {
             unbounded_h
         };
-        
-        CIELCHColor{l, c, h}
+
+        CIELCHColor { l, c, h }
     }
     /// Converts from LCH back to XYZ by way of CIELAB, chromatically adapting it as CIELAB does.
     fn to_xyz(&self, illuminant: Illuminant) -> XYZColor {
@@ -58,22 +58,33 @@ impl Color for CIELCHColor {
         // more math: a = c cos h, b = c sin h
         // Rust also has something for this which is hella cool
         let (sin, cos) = self.h.to_radians().sin_cos();
-        CIELABColor{l: self.l, a: self.c * cos, b: self.c * sin}.to_xyz(illuminant)
+        CIELABColor {
+            l: self.l,
+            a: self.c * cos,
+            b: self.c * sin,
+        }.to_xyz(illuminant)
     }
 }
 
 impl From<Coord> for CIELCHColor {
     fn from(c: Coord) -> CIELCHColor {
-        CIELCHColor{l: c.x, c: c.y, h: c.z}
+        CIELCHColor {
+            l: c.x,
+            c: c.y,
+            h: c.z,
+        }
     }
 }
 
 impl Into<Coord> for CIELCHColor {
     fn into(self) -> Coord {
-        Coord{x: self.l, y: self.c, z: self.h}
+        Coord {
+            x: self.l,
+            y: self.c,
+            z: self.h,
+        }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -83,24 +94,48 @@ mod tests {
 
     #[test]
     fn test_lch_xyz_conversion_same_illuminant() {
-        let xyz = XYZColor{x: 0.2, y: 0.42, z: 0.23, illuminant: Illuminant::D50};
+        let xyz = XYZColor {
+            x: 0.2,
+            y: 0.42,
+            z: 0.23,
+            illuminant: Illuminant::D50,
+        };
         let lch: CIELCHColor = xyz.convert();
         let xyz2: XYZColor = lch.convert();
-        println!("{} {} {} {} {} {}", xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z);
+        println!(
+            "{} {} {} {} {} {}",
+            xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z
+        );
         assert!(xyz2.approx_equal(&xyz));
     }
     #[test]
     fn test_lch_xyz_conversion_different_illuminant() {
-        let xyz = XYZColor{x: 0.2, y: 0.42, z: 0.23, illuminant: Illuminant::D55};
+        let xyz = XYZColor {
+            x: 0.2,
+            y: 0.42,
+            z: 0.23,
+            illuminant: Illuminant::D55,
+        };
         let lch: CIELCHColor = xyz.convert();
         let xyz2: XYZColor = lch.convert();
-        println!("{} {} {} {} {} {}", xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z);
+        println!(
+            "{} {} {} {} {} {}",
+            xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z
+        );
         assert!(xyz2.approx_visually_equal(&xyz));
     }
     #[test]
     fn test_cielch_color_mixing() {
-        let lch = CIELCHColor{l: 50.0, c: 40.0, h: 65.0};
-        let lch2 = CIELCHColor{l: 60.0, c: 25.0, h: 75.0};
+        let lch = CIELCHColor {
+            l: 50.0,
+            c: 40.0,
+            h: 65.0,
+        };
+        let lch2 = CIELCHColor {
+            l: 60.0,
+            c: 25.0,
+            h: 75.0,
+        };
         let lch_mixed = lch.mix(lch2);
         assert!((lch_mixed.l - 55.0).abs() <= 1e-7);
         assert!((lch_mixed.c - 32.5).abs() <= 1e-7);

--- a/src/colors/cielchuvcolor.rs
+++ b/src/colors/cielchuvcolor.rs
@@ -24,7 +24,6 @@ pub struct CIELCHuvColor {
     pub h: f64,
 }
 
-
 impl Color for CIELCHuvColor {
     /// Converts from XYZ to CIELCHuv through CIELUV.
     fn from_xyz(xyz: XYZColor) -> CIELCHuvColor {
@@ -34,26 +33,34 @@ impl Color for CIELCHuvColor {
         // compute c and h using f64 methods
         let h = luv.v.atan2(luv.u);
         let c = luv.v.hypot(luv.u);
-        CIELCHuvColor{l: luv.l, c, h}
+        CIELCHuvColor { l: luv.l, c, h }
     }
     /// Gets the XYZ color that corresponds to this one, through CIELUV.
     fn to_xyz(&self, illuminant: Illuminant) -> XYZColor {
         // go through CIELUV
         let u = self.c * self.h.cos();
         let v = self.c * self.h.sin();
-        CIELUVColor{l: self.l, u, v}.to_xyz(illuminant)
-    }        
+        CIELUVColor { l: self.l, u, v }.to_xyz(illuminant)
+    }
 }
 
 impl From<Coord> for CIELCHuvColor {
     fn from(c: Coord) -> CIELCHuvColor {
-        CIELCHuvColor{l: c.x, c: c.y, h: c.z}
+        CIELCHuvColor {
+            l: c.x,
+            c: c.y,
+            h: c.z,
+        }
     }
 }
 
 impl Into<Coord> for CIELCHuvColor {
     fn into(self) -> Coord {
-        Coord{x: self.l, y: self.c, z: self.h}
+        Coord {
+            x: self.l,
+            y: self.c,
+            z: self.h,
+        }
     }
 }
 
@@ -65,7 +72,12 @@ mod tests {
 
     #[test]
     fn test_cielchuv_xyz_conversion_d50() {
-        let xyz = XYZColor{x: 0.4, y: 0.6, z: 0.2, illuminant: Illuminant::D50};
+        let xyz = XYZColor {
+            x: 0.4,
+            y: 0.6,
+            z: 0.2,
+            illuminant: Illuminant::D50,
+        };
         let lchuv: CIELCHuvColor = xyz.convert();
         let xyz2: XYZColor = lchuv.convert();
         assert!(xyz.approx_visually_equal(&xyz2));
@@ -73,7 +85,12 @@ mod tests {
 
     #[test]
     fn test_cielchuv_xyz_conversion_d65() {
-        let xyz = XYZColor{x: 0.4, y: 0.6, z: 0.2, illuminant: Illuminant::D65};
+        let xyz = XYZColor {
+            x: 0.4,
+            y: 0.6,
+            z: 0.2,
+            illuminant: Illuminant::D65,
+        };
         let lchuv: CIELCHuvColor = xyz.convert();
         let xyz2: XYZColor = lchuv.convert();
         assert!(xyz.approx_visually_equal(&xyz2));
@@ -81,8 +98,16 @@ mod tests {
 
     #[test]
     fn test_cielchuv_xyz_mixing() {
-        let lch = CIELCHuvColor{l: 50.0, c: 45.0, h: 27.0};
-        let lch2 = CIELCHuvColor{l: 70.0, c: 25.0, h: 127.0};
+        let lch = CIELCHuvColor {
+            l: 50.0,
+            c: 45.0,
+            h: 27.0,
+        };
+        let lch2 = CIELCHuvColor {
+            l: 70.0,
+            c: 25.0,
+            h: 127.0,
+        };
         let lch3 = lch.mix(lch2);
         assert!((lch3.l - 60.0).abs() <= 1e-7);
         assert!((lch3.c - 35.0).abs() <= 1e-7);

--- a/src/colors/cieluvcolor.rs
+++ b/src/colors/cieluvcolor.rs
@@ -6,7 +6,6 @@ use color::{Color, XYZColor};
 use coord::Coord;
 use illuminants::Illuminant;
 
-
 #[derive(Debug, Copy, Clone)]
 pub struct CIELUVColor {
     /// The luminance component of LUV. Ranges from 0 to 100 by definition.
@@ -30,16 +29,10 @@ impl Color for CIELUVColor {
         // because cieluv chromatic adaptation sucks, use the good one
         let xyz_c = xyz.color_adapt(Illuminant::D50);
         let wp = XYZColor::white_point(Illuminant::D50);
-        let denom = |color: XYZColor| {
-            color.x + 15.0 * color.y + 3.0 * color.z
-        };
-        let u_func = |color: XYZColor| {
-            4.0 * color.x / denom(color)
-        };
-        let v_func = |color: XYZColor| {
-            9.0 * color.y / denom(color)
-        };
-            
+        let denom = |color: XYZColor| color.x + 15.0 * color.y + 3.0 * color.z;
+        let u_func = |color: XYZColor| 4.0 * color.x / denom(color);
+        let v_func = |color: XYZColor| 9.0 * color.y / denom(color);
+
         let u_prime_n = u_func(wp);
         let v_prime_n = v_func(wp);
 
@@ -59,7 +52,7 @@ impl Color for CIELUVColor {
 
         let u = 13.0 * l * (u_prime - u_prime_n);
         let v = 13.0 * l * (v_prime - v_prime_n);
-        CIELUVColor{l, u, v}
+        CIELUVColor { l, u, v }
     }
     /// Returns a new `XYZColor` that matches the given color. Note that Scarlet uses CIELUV D50 to
     /// get around compatibility issues, so any other illuminant will be chromatically adapted after
@@ -68,44 +61,51 @@ impl Color for CIELUVColor {
         // https://en.wikipedia.org/wiki/CIELUV literally has the equations in order
         // pretty straightforward
         let wp = XYZColor::white_point(Illuminant::D50);
-        let denom = |color: XYZColor| {
-            color.x + 15.0 * color.y + 3.0 * color.z
-        };
-        let u_func = |color: XYZColor| {
-            4.0 * color.x / denom(color)
-        };
-        let v_func = |color: XYZColor| {
-            9.0 * color.y / denom(color)
-        };
+        let denom = |color: XYZColor| color.x + 15.0 * color.y + 3.0 * color.z;
+        let u_func = |color: XYZColor| 4.0 * color.x / denom(color);
+        let v_func = |color: XYZColor| 9.0 * color.y / denom(color);
         let u_prime_n = u_func(wp);
         let v_prime_n = v_func(wp);
 
         let u_prime = self.u / (13.0 * self.l) + u_prime_n;
         let v_prime = self.v / (13.0 * self.l) + v_prime_n;
-        
+
         let delta: f64 = 6.0 / 29.0;
-        
+
         let y = if self.l <= 8.0 {
             wp.y * self.l * (delta / 2.0).powf(3.0)
         } else {
             wp.y * ((self.l + 16.0) / 116.0).powf(3.0)
         };
-        
+
         let x = y * 9.0 * u_prime / (4.0 * v_prime);
         let z = y * (12.0 - 3.0 * u_prime - 20.0 * v_prime) / (4.0 * v_prime);
-        XYZColor{x, y, z, illuminant: Illuminant::D50}.color_adapt(illuminant)
+        XYZColor {
+            x,
+            y,
+            z,
+            illuminant: Illuminant::D50,
+        }.color_adapt(illuminant)
     }
 }
 
 impl From<Coord> for CIELUVColor {
     fn from(c: Coord) -> CIELUVColor {
-        CIELUVColor{l: c.x, u: c.y, v: c.z}
+        CIELUVColor {
+            l: c.x,
+            u: c.y,
+            v: c.z,
+        }
     }
 }
 
 impl Into<Coord> for CIELUVColor {
     fn into(self) -> Coord {
-        Coord{x: self.l, y: self.u, z: self.v}
+        Coord {
+            x: self.l,
+            y: self.u,
+            z: self.v,
+        }
     }
 }
 
@@ -114,10 +114,15 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     use color::Mix;
-    
+
     #[test]
     fn test_cieluv_xyz_conversion_d50() {
-        let xyz = XYZColor{x: 0.3, y: 0.53, z: 0.65, illuminant: Illuminant::D50};
+        let xyz = XYZColor {
+            x: 0.3,
+            y: 0.53,
+            z: 0.65,
+            illuminant: Illuminant::D50,
+        };
         let luv: CIELUVColor = xyz.convert();
         let xyz2: XYZColor = luv.convert();
         assert!(xyz2.approx_equal(&xyz));
@@ -125,7 +130,12 @@ mod tests {
 
     #[test]
     fn test_cieluv_xyz_conversion_d65() {
-        let xyz = XYZColor{x: 0.3, y: 0.53, z: 0.65, illuminant: Illuminant::D65};
+        let xyz = XYZColor {
+            x: 0.3,
+            y: 0.53,
+            z: 0.65,
+            illuminant: Illuminant::D65,
+        };
         let luv: CIELUVColor = xyz.convert();
         let xyz2: XYZColor = luv.convert();
         assert!(xyz2.approx_visually_equal(&xyz));
@@ -133,8 +143,16 @@ mod tests {
 
     #[test]
     fn test_cieluv_color_mixing() {
-        let luv = CIELUVColor{l: 45.0, u: 67.0, v: 49.0};
-        let luv2 = CIELUVColor{l: 53.0, u: 59.0, v: 3.0};
+        let luv = CIELUVColor {
+            l: 45.0,
+            u: 67.0,
+            v: 49.0,
+        };
+        let luv2 = CIELUVColor {
+            l: 53.0,
+            u: 59.0,
+            v: 3.0,
+        };
         let luv_mixed = luv.mix(luv2);
         assert!((luv_mixed.l - 49.0).abs() <= 1e-7);
         assert!((luv_mixed.u - 63.0).abs() <= 1e-7);

--- a/src/colors/rommrgbcolor.rs
+++ b/src/colors/rommrgbcolor.rs
@@ -7,14 +7,12 @@
 //! 1) maps to it. It also have to undo the nonlinearity and flare correction, which could still
 //! contain small errors.
 
-
 use color::{Color, XYZColor};
 use coord::Coord;
 use consts::ROMM_RGB_TRANSFORM_MAT as ROMM;
 use consts;
 use na::Vector3;
 use illuminants::Illuminant;
-
 
 #[derive(Debug, Copy, Clone)]
 pub struct ROMMRGBColor {
@@ -45,8 +43,7 @@ impl Color for ROMMRGBColor {
             // exact one if it's a nicer format and probably causes fewer float issues
             if x < (2.0f64).powf(-9.0) {
                 x * 16.0
-            }
-            else {
+            } else {
                 x.powf(1.0 / 1.8)
             }
         };
@@ -56,28 +53,23 @@ impl Color for ROMMRGBColor {
         let fix_flare = |x: f64| {
             if x < 0.03125 {
                 0.003473 + 0.0622829 * x
-            }
-            else {
+            } else {
                 0.003473 + 0.996527 * x.powf(1.8)
             }
         };
 
-
-        
         // we also need to clamp between 0 and 1
         let clamp = |x: f64| {
             if x < 0.0 {
                 0.0
-            }
-            else if x > 1.0 {
+            } else if x > 1.0 {
                 1.0
-            }
-            else {
+            } else {
                 x
             }
-        };   
+        };
         // now just apply these in sequence
-        ROMMRGBColor{
+        ROMMRGBColor {
             r: fix_flare(gamma(clamp(rr_gg_bb[0]))),
             g: fix_flare(gamma(clamp(rr_gg_bb[1]))),
             b: fix_flare(gamma(clamp(rr_gg_bb[2]))),
@@ -91,11 +83,12 @@ impl Color for ROMMRGBColor {
     fn to_xyz(&self, illuminant: Illuminant) -> XYZColor {
         // undo the gamma function, find the piecewise split
         let gamma_inv = |x: f64| {
-            if x >= 0.03125 { // junction of two piecewise parts
+            if x >= 0.03125 {
+                // junction of two piecewise parts
                 // this is the exponential part
                 x.powf(1.8)
-            }
-            else { // this is the linear part
+            } else {
+                // this is the linear part
                 x / 16.0
             }
         };
@@ -105,10 +98,11 @@ impl Color for ROMMRGBColor {
         // WolframAlpha is my source for all of the calcluations
         let fix_flare_inv = |x: f64| {
             // fix_flare(2 ^ -9) is cutoff
-            if x >= 0.005419340625 { // x originally came out of the second part of the cutoff 
+            if x >= 0.005419340625 {
+                // x originally came out of the second part of the cutoff
                 ((x - 0.003473) / 0.996527).powf(1.0 / 1.8)
-            }
-            else { // x originally came out of the first part of the cutoff
+            } else {
+                // x originally came out of the first part of the cutoff
                 (x - 0.003473) / 0.0622829
             }
         };
@@ -133,16 +127,23 @@ impl Color for ROMMRGBColor {
 
 impl From<Coord> for ROMMRGBColor {
     fn from(c: Coord) -> ROMMRGBColor {
-        ROMMRGBColor{r: c.x, g: c.y, b: c.z}
+        ROMMRGBColor {
+            r: c.x,
+            g: c.y,
+            b: c.z,
+        }
     }
 }
 
 impl Into<Coord> for ROMMRGBColor {
     fn into(self) -> Coord {
-        Coord{x: self.r, y: self.g, z: self.b}
+        Coord {
+            x: self.r,
+            y: self.g,
+            z: self.b,
+        }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -152,14 +153,23 @@ mod tests {
 
     #[test]
     fn test_romm_rgb_xyz_conversion() {
-        let xyz = XYZColor{x: 0.4, y: 0.5, z: 0.6, illuminant: Illuminant::D50};
+        let xyz = XYZColor {
+            x: 0.4,
+            y: 0.5,
+            z: 0.6,
+            illuminant: Illuminant::D50,
+        };
         let rgb = ROMMRGBColor::from_xyz(xyz);
         let xyz2: XYZColor = rgb.to_xyz(Illuminant::D50);
         assert!(xyz.approx_equal(&xyz2));
     }
     #[test]
     fn test_xyz_romm_rgb_conversion() {
-        let rgb = ROMMRGBColor{r: 0.6, g: 0.3, b: 0.8};
+        let rgb = ROMMRGBColor {
+            r: 0.6,
+            g: 0.3,
+            b: 0.8,
+        };
         let xyz = rgb.to_xyz(Illuminant::D50);
         let rgb2 = ROMMRGBColor::from_xyz(xyz);
         assert!((rgb.r - rgb2.r).abs() <= 0.001);
@@ -168,7 +178,11 @@ mod tests {
     }
     #[test]
     fn test_error_accumulation_romm_rgb() {
-        let rgb = ROMMRGBColor{r: 0.6, g: 0.3, b: 0.8};
+        let rgb = ROMMRGBColor {
+            r: 0.6,
+            g: 0.3,
+            b: 0.8,
+        };
         let xyz = rgb.to_xyz(Illuminant::D50);
         let mut rgb2 = ROMMRGBColor::from_xyz(xyz);
         for _i in 0..20 {
@@ -176,28 +190,44 @@ mod tests {
             println!("{} {} {}", rgb2.r, rgb2.g, rgb2.b);
             assert!((rgb.r - rgb2.r).abs() <= 1e-4);
             assert!((rgb.g - rgb2.g).abs() <= 1e-4);
-            assert!((rgb.b - rgb2.b).abs() <= 1e-4);            
+            assert!((rgb.b - rgb2.b).abs() <= 1e-4);
         }
     }
-        
+
     #[test]
     fn test_romm_rgb_xyz_conversion_with_gamut() {
         let wp = Illuminant::D65.white_point();
-        let xyz = XYZColor{x: wp[0], y: wp[1], z: wp[2], illuminant: Illuminant::D65};
+        let xyz = XYZColor {
+            x: wp[0],
+            y: wp[1],
+            z: wp[2],
+            illuminant: Illuminant::D65,
+        };
         let rgb: ROMMRGBColor = ROMMRGBColor::from_xyz(xyz);
         let xyz2 = rgb.to_xyz(Illuminant::D65);
         println!("{} {} {}", rgb.r, rgb.g, rgb.b);
-        println!("{} {} {} {} {} {}", xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z);
+        println!(
+            "{} {} {} {} {} {}",
+            xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z
+        );
         assert!(xyz.approx_visually_equal(&xyz2));
     }
 
     #[test]
     fn test_romm_rgb_color_mixing() {
-        let rgb = ROMMRGBColor{r: 0.2, g: 0.3, b: 0.4};
-        let rgb2 = ROMMRGBColor{r: 0.5, g: 0.5, b: 0.6};
+        let rgb = ROMMRGBColor {
+            r: 0.2,
+            g: 0.3,
+            b: 0.4,
+        };
+        let rgb2 = ROMMRGBColor {
+            r: 0.5,
+            g: 0.5,
+            b: 0.6,
+        };
         let rgb_mixed = rgb.mix(rgb2);
         assert!((rgb_mixed.r - 0.35).abs() <= 1e-7);
         assert!((rgb_mixed.g - 0.4).abs() <= 1e-7);
         assert!((rgb_mixed.b - 0.5).abs() <= 1e-7);
     }
-}       
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -5,10 +5,7 @@
 //! change the result at all, e.g., converting to an illuminant and back again. Thus, this method
 //! allows for saner checking of constant values and guaranteed precision in inversion.
 
-use na::{Matrix3};
-
-
-
+use na::Matrix3;
 
 /// Not safe for general use. If `const fn` was stable, it would be used instead. The only reason this
 /// is here is to calculate the inverse of constant matrices. This panics on singular matrices!
@@ -20,39 +17,62 @@ pub fn inv(m: Matrix3<f64>) -> Matrix3<f64> {
     }
 }
 
-
 #[allow(non_snake_case)]
 pub fn ADOBE_RGB_TRANSFORM_MAT() -> Matrix3<f64> {
     Matrix3::new(
-        02.04159, -0.56501, -0.34473,
-        -0.96924, 01.87957, 00.04156,
-        00.01344, -0.11836, 01.01517,
+        02.04159,
+        -0.56501,
+        -0.34473,
+        -0.96924,
+        01.87957,
+        00.04156,
+        00.01344,
+        -0.11836,
+        01.01517,
     )
-}   
+}
 
 #[allow(non_snake_case)]
 pub fn BRADFORD_TRANSFORM_MAT() -> Matrix3<f64> {
     Matrix3::new(
-        00.8951, 00.2664, -0.1614,
-        -0.7502, 01.7135, 00.0367,
-        00.0389, -0.0685, 01.0296,
+        00.8951,
+        00.2664,
+        -0.1614,
+        -0.7502,
+        01.7135,
+        00.0367,
+        00.0389,
+        -0.0685,
+        01.0296,
     )
 }
 
 #[allow(non_snake_case)]
 pub fn ROMM_RGB_TRANSFORM_MAT() -> Matrix3<f64> {
     Matrix3::new(
-        0.7976749, 0.1351917, 0.0313534,
-        0.2880402, 0.7118741, 0.0000857,
-        0.0000000, 0.0000000, 0.8252100
+        0.7976749,
+        0.1351917,
+        0.0313534,
+        0.2880402,
+        0.7118741,
+        0.0000857,
+        0.0000000,
+        0.0000000,
+        0.8252100,
     )
 }
 
 #[allow(non_snake_case)]
-pub fn STANDARD_RGB_TRANSFORM_MAT() ->  Matrix3<f64> {
+pub fn STANDARD_RGB_TRANSFORM_MAT() -> Matrix3<f64> {
     Matrix3::new(
-        03.2406, -1.5372, -0.4986,
-        -0.9689, 01.8758, 00.0415,
-        00.0557, -0.2040, 01.0570,
+        03.2406,
+        -1.5372,
+        -0.4986,
+        -0.9689,
+        01.8758,
+        00.0415,
+        00.0557,
+        -0.2040,
+        01.0570,
     )
 }

--- a/src/coord.rs
+++ b/src/coord.rs
@@ -2,21 +2,20 @@
 /// dimensions with scalars and other Coordinates. Used to unify math with colors that is the same,
 /// just with different projections into 3D space.
 
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Sub};
 extern crate num;
-use self::num::{NumCast, Num};
+use self::num::{Num, NumCast};
 
-pub trait Scalar : NumCast + Num {}
+pub trait Scalar: NumCast + Num {}
 
 impl<T: NumCast + Num> Scalar for T {}
-
 
 /// A point in 3D space.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Coord {
     pub x: f64,
     pub y: f64,
-    pub z: f64
+    pub z: f64,
 }
 
 /// Now we implement addition and subtraction, as well as division and multiplication by scalars. Note
@@ -28,8 +27,8 @@ impl Add for Coord {
         return Coord {
             x: self.x + rhs.x,
             y: self.y + rhs.y,
-            z: self.z + rhs.z
-        }
+            z: self.z + rhs.z,
+        };
     }
 }
 
@@ -41,8 +40,8 @@ impl Sub for Coord {
         return Coord {
             x: self.x - rhs.x,
             y: self.y - rhs.y,
-            z: self.z - rhs.z
-        }
+            z: self.z - rhs.z,
+        };
     }
 }
 
@@ -55,8 +54,8 @@ impl<U: Scalar> Mul<U> for Coord {
         return Coord {
             x: self.x * r,
             y: self.y * r,
-            z: self.z * r
-        }
+            z: self.z * r,
+        };
     }
 }
 
@@ -65,13 +64,12 @@ impl<U: Scalar> Div<U> for Coord {
     fn div(self, rhs: U) -> Coord {
         if rhs.is_zero() {
             panic!("Division by 0!");
-        }
-        else {
+        } else {
             let r: f64 = num::cast(rhs).unwrap();
             Coord {
                 x: self.x / r,
                 y: self.y / r,
-                z: self.z / r
+                z: self.z / r,
             }
         }
     }
@@ -81,21 +79,26 @@ impl<U: Scalar> Div<U> for Coord {
 impl Coord {
     /// The midpoint between two 3D points: returns a new Coord.
     pub fn midpoint(&self, other: &Coord) -> Coord {
-        Coord{x: (&self.x + &other.x) / 2.0,
-              y: (&self.y + &other.y) / 2.0,
-              z: (&self.z + &other.z) / 2.0}
+        Coord {
+            x: (&self.x + &other.x) / 2.0,
+            y: (&self.y + &other.y) / 2.0,
+            z: (&self.z + &other.z) / 2.0,
+        }
     }
     /// The weighted midpoint: like midpoint, but with weighted averages instead of the arithmetic
     /// mean. Very strange things may happen if the weight is not between 0 and 1.
     pub fn weighted_midpoint(&self, other: &Coord, weight: f64) -> Coord {
-        Coord{x: (&self.x * weight + (1.0 - weight) * &other.x),
-              y: (&self.y * weight + (1.0 - weight) * &other.y),
-              z: (&self.z * weight + (1.0 - weight) * &other.z)}
+        Coord {
+            x: (&self.x * weight + (1.0 - weight) * &other.x),
+            y: (&self.y * weight + (1.0 - weight) * &other.y),
+            z: (&self.z * weight + (1.0 - weight) * &other.z),
+        }
     }
     /// The Euclidean difference between two 3D points, defined as the square root of the sum of
     /// squares of differences in each axis.
     pub fn euclidean_distance(&self, other: &Coord) -> f64 {
-        ((self.x - other.x).powi(2) + (self.y - other.y).powi(2) + (self.z - other.z).powi(2)).sqrt()
+        ((self.x - other.x).powi(2) + (self.y - other.y).powi(2) + (self.z - other.z).powi(2))
+            .sqrt()
     }
     /// Gets the arithmetic mean of `self`, alongside other coordinates.
     pub fn average(self, others: Vec<Coord>) -> Coord {

--- a/src/illuminants.rs
+++ b/src/illuminants.rs
@@ -3,7 +3,7 @@
 //! standard](https://www.astm.org/Standards/E308.htm). The only one I could find available freely was
 //! the outdated E308-01 standard, but these values should be the same: they're both copied
 //! photographically from the CIE standard itself. These are normalized so that the Y (luminance)
-//! value is 100. 
+//! value is 100.
 
 /// A listing of the supported CIE standard illuminants, standards that describe a particular set of
 /// lighting conditions. The most common ones for computers are D50 and D65, differing kinds of
@@ -16,9 +16,8 @@ pub enum Illuminant {
     D65,
     D75,
     /// Represents a light of any given hue, as an array [X, Y, Z] in CIE 1931 space.
-    Custom([f64; 3])
+    Custom([f64; 3]),
 }
-
 
 /// An array of illuminants, in alphabetical and numerical order (the same order as below).
 pub static ILLUMINANTS: [Illuminant; 4] = [
@@ -36,7 +35,7 @@ pub static ILLUMINANT_WHITE_POINTS: [[f64; 3]; 4] = [
     [0.96422, 1.00000, 0.82521],
     [0.95682, 1.00000, 0.92129],
     [0.95047, 1.00000, 1.08884],
-    [0.94972, 1.00000, 1.22638]
+    [0.94972, 1.00000, 1.22638],
 ];
 
 impl Illuminant {
@@ -47,11 +46,7 @@ impl Illuminant {
             Illuminant::D55 => ILLUMINANT_WHITE_POINTS[1],
             Illuminant::D65 => ILLUMINANT_WHITE_POINTS[2],
             Illuminant::D75 => ILLUMINANT_WHITE_POINTS[3],
-            Illuminant::Custom(xyz) => [
-                xyz[0] / xyz[1],
-                1.0,
-                xyz[2] / xyz[1],
-            ]
+            Illuminant::Custom(xyz) => [xyz[0] / xyz[1], 1.0, xyz[2] / xyz[1]],
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
-extern crate termion;
 extern crate csv;
+extern crate geo;
+extern crate nalgebra as na;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate geo;
-extern crate nalgebra as na;
-
+extern crate termion;
 
 pub mod coord;
 pub mod consts;

--- a/src/visual_gamut.rs
+++ b/src/visual_gamut.rs
@@ -29,7 +29,7 @@ pub fn read_cie_spectral_data() -> (Vec<u16>, Vec<XYZColor>) {
         // we should panic on bad data: this file is supplied by us!
         let record: Record = result.unwrap();
         wavelengths.push(record.wavelength);
-        xyz_data.push(XYZColor{
+        xyz_data.push(XYZColor {
             x: record.xbar,
             y: record.ybar,
             z: record.zbar,
@@ -38,4 +38,3 @@ pub fn read_cie_spectral_data() -> (Vec<u16>, Vec<XYZColor>) {
     }
     (wavelengths, xyz_data)
 }
-


### PR DESCRIPTION
This pull request standardizes the formatting of all the Rust code in the repository with `rustfmt`.