### PR TITLE
Remove dependency on termion. Reformat using cargo fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ categories = ["multimedia::images", "visualization", "data-structures"]
 
 [dependencies]
 regex = "1.0"
-termion = "1.5"
 num = "0.2"
 float-cmp = "0.4.0"
 csv = "1.0.2"
 serde = "1"
 serde_derive = "1"
 geo = "0.10"
-rulinalg="0.4.2"
+rulinalg = "0.4.2"
 maplit = "1.0.1"
 lazy_static = "1.1"
 

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -2,11 +2,9 @@
 //! colors a color gamut supports. For example, the sRGB gamut only supports RGB values ranging from
 //! 0-1 that are scaled to 0-255, which is about 30% of the total visible range of human vision.
 
-
 use color::{Color, RGBColor};
 use colorpoint::ColorPoint;
 use coord::Coord;
-
 
 /// Describes a color space in which the total space of representable colors has explicit bounds
 /// besides those imposed by human vision. For example, an sRGB color can't have negative values for
@@ -76,7 +74,6 @@ impl Bound for RGBColor {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::Bound;
@@ -92,13 +89,13 @@ mod tests {
             g: -0.2,
             b: 1.2,
         };
-        assert!(RGBColor::clamp(color1).visually_indistinguishable(
-            &RGBColor {
+        assert!(
+            RGBColor::clamp(color1).visually_indistinguishable(&RGBColor {
                 r: 0.1,
                 g: 0.,
                 b: 1.,
-            },
-        ));
+            },)
+        );
     }
 
     #[test]
@@ -119,19 +116,19 @@ mod tests {
             v: 0.7,
         };
         assert!(color3.visually_indistinguishable(&HSVColor::clamp(color3)));
-        assert!(HSVColor::clamp(color2).visually_indistinguishable(
-            &HSVColor {
+        assert!(
+            HSVColor::clamp(color2).visually_indistinguishable(&HSVColor {
                 h: 360.,
                 s: 0.2,
                 v: 0.5,
-            },
-        ));
-        assert!(HSLColor::clamp(color1).visually_indistinguishable(
-            &HSLColor {
+            },)
+        );
+        assert!(
+            HSLColor::clamp(color1).visually_indistinguishable(&HSLColor {
                 h: 0.,
                 s: 0.,
                 l: 1.,
-            },
-        ));
+            },)
+        );
     }
 }

--- a/src/colormap.rs
+++ b/src/colormap.rs
@@ -2,13 +2,11 @@
 //! to colors in a continuous way—and provides some common ones used in programs like MATLAB and in
 //! data visualization everywhere.
 
-
-use std::iter::Iterator;
 use color::{Color, RGBColor};
 use colorpoint::ColorPoint;
 use coord::Coord;
 use matplotlib_cmaps;
-
+use std::iter::Iterator;
 
 /// A trait that models a colormap, a continuous mapping of the numbers between 0 and 1 to
 /// colors. Any color output format is supported, but it must be consistent.
@@ -54,7 +52,6 @@ impl NormalizeMapping {
         }
     }
 }
-
 
 /// A gradient colormap: a continuous, evenly-spaced shift between two colors A and B such that 0 maps
 /// to A, 1 maps to B, and any number in between maps to a weighted mix of them in a given
@@ -109,14 +106,12 @@ impl<T: ColorPoint> ColorMap<T> for GradientColorMap<T> {
         } else {
             x
         };
-        self.start.padded_gradient(
-            &self.end,
-            self.padding.0,
-            self.padding.1,
-        )(self.normalization.normalize(clamped))
+        self.start
+            .padded_gradient(&self.end, self.padding.0, self.padding.1)(
+            self.normalization.normalize(clamped),
+        )
     }
 }
-
 
 /// A colormap that linearly interpolates between a given series of values in an equally-spaced
 /// progression. This is modeled off of the `matplotlib` Python library's `ListedColormap`, and is
@@ -127,7 +122,6 @@ pub struct ListedColorMap {
     /// The list of values, as a vector of `[f64]` arrays that provide equally-spaced RGB values.
     pub vals: Vec<[f64; 3]>,
 }
-
 
 impl<T: ColorPoint> ColorMap<T> for ListedColorMap {
     /// Linearly interpolates by first finding the two colors on either boundary, and then using a
@@ -158,7 +152,8 @@ impl<T: ColorPoint> ColorMap<T> for ListedColorMap {
                 x: arr[0],
                 y: arr[1],
                 z: arr[2],
-            }).convert()
+            })
+            .convert()
         } else {
             // interpolate
             let arr1 = self.vals[ind1];
@@ -185,7 +180,9 @@ impl ListedColorMap {
     // TODO: In the future, I'd like to remove this weird array type bound if possible
     /// Initializes a ListedColorMap from an iterator of arrays [R, G, B].
     pub fn new<T: Iterator<Item = [f64; 3]>>(vals: T) -> ListedColorMap {
-        ListedColorMap { vals: vals.collect() }
+        ListedColorMap {
+            vals: vals.collect(),
+        }
     }
     /// Initializes a viridis colormap, a pleasing blue-green-yellow colormap that is perceptually
     /// uniform with respect to luminance, found in Python's `matplotlib` as the default
@@ -216,8 +213,6 @@ impl ListedColorMap {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
@@ -232,13 +227,7 @@ mod tests {
         let vals = vec![-0.2, 0., 1. / 15., 1. / 5., 4. / 5., 1., 100.];
         let cols = cmap.transform(vals);
         let strs = vec![
-            "#FF0000",
-            "#FF0000",
-            "#EE0011",
-            "#CC0033",
-            "#3300CC",
-            "#0000FF",
-            "#0000FF",
+            "#FF0000", "#FF0000", "#EE0011", "#CC0033", "#3300CC", "#0000FF", "#0000FF",
         ];
         for (i, col) in cols.into_iter().enumerate() {
             assert_eq!(col.to_string(), strs[i]);
@@ -252,13 +241,7 @@ mod tests {
         let vals = vec![-0.2, 0., 1. / 27., 1. / 8., 8. / 27., 1., 100.];
         let cols = cmap.transform(vals);
         let strs = vec![
-            "#CC0000",
-            "#CC0000",
-            "#880044",
-            "#660066",
-            "#440088",
-            "#0000CC",
-            "#0000CC",
+            "#CC0000", "#CC0000", "#880044", "#660066", "#440088", "#0000CC", "#0000CC",
         ];
         for (i, col) in cols.into_iter().enumerate() {
             assert_eq!(col.to_string(), strs[i]);
@@ -274,13 +257,7 @@ mod tests {
         let vals = vec![-0.2, 0., 1. / 27., 1. / 8., 8. / 27., 1., 100.];
         let cols = cmap.transform(vals);
         let strs = vec![
-            "#990033",
-            "#990033",
-            "#770055",
-            "#660066",
-            "#550077",
-            "#330099",
-            "#330099",
+            "#990033", "#990033", "#770055", "#660066", "#550077", "#330099", "#330099",
         ];
         for (i, col) in cols.into_iter().enumerate() {
             assert_eq!(col.to_string(), strs[i]);

--- a/src/colors/adobergbcolor.rs
+++ b/src/colors/adobergbcolor.rs
@@ -3,10 +3,10 @@
 //! primaries designed to give it a wider coverage (over half of CIE 1931).
 
 use bound::Bound;
-use coord::Coord;
 use color::{Color, XYZColor};
 use consts::ADOBE_RGB_TRANSFORM as ADOBE_RGB;
 use consts::ADOBE_RGB_TRANSFORM_LU as ADOBE_RGB_LU;
+use coord::Coord;
 use illuminants::Illuminant;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -56,12 +56,14 @@ impl Color for AdobeRGBColor {
         let rgb = &*ADOBE_RGB * vector![xyz_c.x, xyz_c.y, xyz_c.z];
 
         // clamp
-        let clamp = |x: f64| if x > 1.0 {
-            1.0
-        } else if x < 0.0 {
-            0.0
-        } else {
-            x
+        let clamp = |x: f64| {
+            if x > 1.0 {
+                1.0
+            } else if x < 0.0 {
+                0.0
+            } else {
+                x
+            }
         };
 
         // now we apply gamma transformation
@@ -79,7 +81,8 @@ impl Color for AdobeRGBColor {
         let ungamma = |x: f64| x.powf(563.0 / 256.0);
 
         // more efficient/accurate than using inverses
-        let xyz_vec = ADOBE_RGB_LU.solve(vector![ungamma(self.r), ungamma(self.g), ungamma(self.b)])
+        let xyz_vec = ADOBE_RGB_LU
+            .solve(vector![ungamma(self.r), ungamma(self.g), ungamma(self.b)])
             .expect("Matrix is invertible.");
 
         XYZColor {
@@ -87,7 +90,8 @@ impl Color for AdobeRGBColor {
             y: xyz_vec[1],
             z: xyz_vec[2],
             illuminant: Illuminant::D65,
-        }.color_adapt(illuminant)
+        }
+        .color_adapt(illuminant)
     }
 }
 

--- a/src/colors/cielabcolor.rs
+++ b/src/colors/cielabcolor.rs
@@ -118,7 +118,8 @@ impl Color for CIELABColor {
             y,
             z,
             illuminant: Illuminant::D50,
-        }.color_adapt(illuminant)
+        }
+        .color_adapt(illuminant)
     }
 }
 

--- a/src/colors/cielchcolor.rs
+++ b/src/colors/cielchcolor.rs
@@ -2,10 +2,10 @@
 //! chroma and hue instead of two opponent color axes. Be careful not to confuse this color with
 //! CIEHCL, which uses CIELUV internally.
 
+use super::cielabcolor::CIELABColor;
 use color::{Color, XYZColor};
 use coord::Coord;
 use illuminants::Illuminant;
-use super::cielabcolor::CIELABColor;
 
 /// A cylindrical form of CIELAB, analogous to the relationship between HSL and RGB.
 /// # Example
@@ -48,10 +48,10 @@ impl Color for CIELCHColor {
         // first get LAB coordinates
         let lab = CIELABColor::from_xyz(xyz);
         let l = lab.l; // the same in both spaces
-        // now we have to do some math
-        // radius is sqrt(a^2 + b^2)
-        // angle is atan2(a, b)
-        // Rust does this ez
+                       // now we have to do some math
+                       // radius is sqrt(a^2 + b^2)
+                       // angle is atan2(a, b)
+                       // Rust does this ez
         let c = lab.b.hypot(lab.a);
         // don't forget to convert to degrees
         let unbounded_h = lab.b.atan2(lab.a).to_degrees();
@@ -77,7 +77,8 @@ impl Color for CIELCHColor {
             l: self.l,
             a: self.c * cos,
             b: self.c * sin,
-        }.to_xyz(illuminant)
+        }
+        .to_xyz(illuminant)
     }
 }
 

--- a/src/colors/cieluvcolor.rs
+++ b/src/colors/cieluvcolor.rs
@@ -102,7 +102,8 @@ impl Color for CIELUVColor {
             y,
             z,
             illuminant: Illuminant::D50,
-        }.color_adapt(illuminant)
+        }
+        .color_adapt(illuminant)
     }
 }
 

--- a/src/colors/hslcolor.rs
+++ b/src/colors/hslcolor.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 use bound::Bound;
 use color::{Color, RGBColor, XYZColor};
 use coord::Coord;
-use csscolor::{CSSParseError, parse_hsl_hsv_tuple};
+use csscolor::{parse_hsl_hsv_tuple, CSSParseError};
 use illuminants::Illuminant;
 
 /// A color in the HSL color space, a direct transformation of the sRGB space. sHSL is used to
@@ -188,20 +188,19 @@ impl FromStr for HSLColor {
 
     fn from_str(s: &str) -> Result<HSLColor, CSSParseError> {
         if !s.starts_with("hsl(") {
-            return Err(CSSParseError::InvalidColorSyntax)
+            return Err(CSSParseError::InvalidColorSyntax);
         }
         let tup: String = s.chars().skip(3).collect::<String>();
         match parse_hsl_hsv_tuple(&tup) {
-            Ok(res) => Ok(HSLColor{
+            Ok(res) => Ok(HSLColor {
                 h: res.0,
                 s: res.1,
                 l: res.2,
             }),
-            Err(_e) => Err(_e)
+            Err(_e) => Err(_e),
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/colors/hsvcolor.rs
+++ b/src/colors/hsvcolor.rs
@@ -6,14 +6,13 @@
 //! color appearance parameters and is outclassed by CIELCH for that purpose, but it is nontheless
 //! important as the closest to such a space one can get using only basic transformations of RGB.
 
-
-use std::str::FromStr;
 use std::f64::EPSILON;
+use std::str::FromStr;
 
 use bound::Bound;
-use coord::Coord;
 use color::{Color, RGBColor, XYZColor};
-use csscolor::{CSSParseError, parse_hsl_hsv_tuple};
+use coord::Coord;
+use csscolor::{parse_hsl_hsv_tuple, CSSParseError};
 use illuminants::Illuminant;
 
 /// An HSV color, defining parameters for hue, saturation, and value from the RGB space. This is sHSV
@@ -162,16 +161,16 @@ impl FromStr for HSVColor {
 
     fn from_str(s: &str) -> Result<HSVColor, CSSParseError> {
         if !s.starts_with("hsv(") {
-            return Err(CSSParseError::InvalidColorSyntax)
+            return Err(CSSParseError::InvalidColorSyntax);
         }
         let tup: String = s.chars().skip(3).collect::<String>();
         match parse_hsl_hsv_tuple(&tup) {
-            Ok(res) => Ok(HSVColor{
+            Ok(res) => Ok(HSVColor {
                 h: res.0,
                 s: res.1,
                 v: res.2,
             }),
-            Err(_e) => Err(_e)
+            Err(_e) => Err(_e),
         }
     }
 }

--- a/src/colors/mod.rs
+++ b/src/colors/mod.rs
@@ -5,19 +5,18 @@
 pub mod adobergbcolor;
 pub mod cielabcolor;
 pub mod cielchcolor;
-pub mod cieluvcolor;
 pub mod cielchuvcolor;
+pub mod cieluvcolor;
 pub mod hslcolor;
 pub mod hsvcolor;
 pub mod rommrgbcolor;
-
 
 // for convenience, use this namespace for the color objects
 pub use self::adobergbcolor::AdobeRGBColor;
 pub use self::cielabcolor::CIELABColor;
 pub use self::cielchcolor::CIELCHColor;
-pub use self::cieluvcolor::CIELUVColor;
 pub use self::cielchuvcolor::CIELCHuvColor;
+pub use self::cieluvcolor::CIELUVColor;
 pub use self::hslcolor::HSLColor;
 pub use self::hsvcolor::HSVColor;
 pub use self::rommrgbcolor::ROMMRGBColor;

--- a/src/colors/rommrgbcolor.rs
+++ b/src/colors/rommrgbcolor.rs
@@ -10,11 +10,10 @@
 
 use bound::Bound;
 use color::{Color, XYZColor};
-use coord::Coord;
 use consts::ROMM_RGB_TRANSFORM as ROMM;
 use consts::ROMM_RGB_TRANSFORM_LU as ROMM_LU;
+use coord::Coord;
 use illuminants::Illuminant;
-
 
 /// A color in the ROMM RGB color space, also known as the ProPhoto RGB space. This is a very wide RGB
 /// gamut, wider than both Adobe RGB and sRGB, but the tradeoff is that the colors it uses as
@@ -77,19 +76,23 @@ impl Color for ROMMRGBColor {
 
         // as the spec describes, some "flare" can occur: to fix this, we apply a small fix so that
         // black is just really small and not 0
-        let fix_flare = |x: f64| if x < 0.03125 {
-            0.003473 + 0.0622829 * x
-        } else {
-            0.003473 + 0.996527 * x.powf(1.8)
+        let fix_flare = |x: f64| {
+            if x < 0.03125 {
+                0.003473 + 0.0622829 * x
+            } else {
+                0.003473 + 0.996527 * x.powf(1.8)
+            }
         };
 
         // we also need to clamp between 0 and 1
-        let clamp = |x: f64| if x < 0.0 {
-            0.0
-        } else if x > 1.0 {
-            1.0
-        } else {
-            x
+        let clamp = |x: f64| {
+            if x < 0.0 {
+                0.0
+            } else if x > 1.0 {
+                1.0
+            } else {
+                x
+            }
         };
         // now just apply these in sequence
         ROMMRGBColor {
@@ -138,8 +141,9 @@ impl Color for ROMMRGBColor {
         // The standard brilliantly decided to not even bother adding an inverse matrix. Scarlet uses
         // LU decomposition to avoid any precision loss when solving the equation for the right
         // values. This might differ from other solutions elsewhere: trust this one, unless you have
-        // a good reason not to.        
-        let xyz = ROMM_LU.solve(vector![r_c, g_c, b_c])
+        // a good reason not to.
+        let xyz = ROMM_LU
+            .solve(vector![r_c, g_c, b_c])
             .expect("Matrix is invertible.");
         // now we convert from D50 to whatever space we need and we're done!
         XYZColor {
@@ -147,7 +151,8 @@ impl Color for ROMMRGBColor {
             y: xyz[1],
             z: xyz[2],
             illuminant: Illuminant::D50,
-        }.color_adapt(illuminant)
+        }
+        .color_adapt(illuminant)
     }
 }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -20,33 +20,29 @@ lazy_static! {
                 -0.96924, 01.87957, 00.04156;
                 00.01344, -0.11836, 01.01517]
     };
-    pub(crate) static ref ADOBE_RGB_TRANSFORM_LU: PartialPivLu<f64> = {
-        PartialPivLu::decompose(ADOBE_RGB_TRANSFORM.clone()).expect("Matrix is invertible.")
-    };
-    pub(crate) static ref BRADFORD_TRANSFORM: Matrix<f64> = {        
+    pub(crate) static ref ADOBE_RGB_TRANSFORM_LU: PartialPivLu<f64> =
+        { PartialPivLu::decompose(ADOBE_RGB_TRANSFORM.clone()).expect("Matrix is invertible.") };
+    pub(crate) static ref BRADFORD_TRANSFORM: Matrix<f64> = {
         matrix![00.8951, 00.2664, -0.1614;
                 -0.7502, 01.7135, 00.0367;
                 00.0389, -0.0685, 01.0296]
     };
-    pub(crate) static ref BRADFORD_TRANSFORM_LU: PartialPivLu<f64> = {
-        PartialPivLu::decompose(BRADFORD_TRANSFORM.clone()).expect("Matrix is invertible.")
-    };
+    pub(crate) static ref BRADFORD_TRANSFORM_LU: PartialPivLu<f64> =
+        { PartialPivLu::decompose(BRADFORD_TRANSFORM.clone()).expect("Matrix is invertible.") };
     pub(crate) static ref ROMM_RGB_TRANSFORM: Matrix<f64> = {
         matrix![0.7976749, 0.1351917, 0.0313534;
                 0.2880402, 0.7118741, 0.0000857;
                 0.0000000, 0.0000000, 0.8252100]
     };
-    pub(crate) static ref ROMM_RGB_TRANSFORM_LU: PartialPivLu<f64> = {
-        PartialPivLu::decompose(ROMM_RGB_TRANSFORM.clone()).expect("Matrix is invertible.")
-    };
+    pub(crate) static ref ROMM_RGB_TRANSFORM_LU: PartialPivLu<f64> =
+        { PartialPivLu::decompose(ROMM_RGB_TRANSFORM.clone()).expect("Matrix is invertible.") };
     pub(crate) static ref STANDARD_RGB_TRANSFORM: Matrix<f64> = {
         matrix![03.2406, -1.5372, -0.4986;
                 -0.9689, 01.8758, 00.0415;
-                00.0557, -0.2040, 01.0570]            
+                00.0557, -0.2040, 01.0570]
     };
-    pub(crate) static ref STANDARD_RGB_TRANSFORM_LU: PartialPivLu<f64> = {
-        PartialPivLu::decompose(STANDARD_RGB_TRANSFORM.clone()).expect("Matrix is invertible.")
-    };
+    pub(crate) static ref STANDARD_RGB_TRANSFORM_LU: PartialPivLu<f64> =
+        { PartialPivLu::decompose(STANDARD_RGB_TRANSFORM.clone()).expect("Matrix is invertible.") };
 }
 
 // These next two constants define the X11 color names and hex codes.
@@ -206,152 +202,23 @@ pub(crate) const X11_NAMES: [&str; 148] = [
 ];
 
 pub(crate) const X11_COLOR_CODES: [&str; 148] = [
-    "#f0f8ff",
-    "#faebd7",
-    "#00ffff",
-    "#7fffd4",
-    "#f0ffff",
-    "#f5f5dc",
-    "#ffe4c4",
-    "#000000",
-    "#ffebcd",
-    "#0000ff",
-    "#8a2be2",
-    "#a52a2a",
-    "#deb887",
-    "#5f9ea0",
-    "#7fff00",
-    "#d2691e",
-    "#ff7f50",
-    "#6495ed",
-    "#fff8dc",
-    "#dc143c",
-    "#00ffff",
-    "#00008b",
-    "#008b8b",
-    "#b8860b",
-    "#a9a9a9",
-    "#006400",
-    "#a9a9a9",
-    "#bdb76b",
-    "#8b008b",
-    "#556b2f",
-    "#ff8c00",
-    "#9932cc",
-    "#8b0000",
-    "#e9967a",
-    "#8fbc8f",
-    "#483d8b",
-    "#2f4f4f",
-    "#2f4f4f",
-    "#00ced1",
-    "#9400d3",
-    "#ff1493",
-    "#00bfff",
-    "#696969",
-    "#696969",
-    "#1e90ff",
-    "#b22222",
-    "#fffaf0",
-    "#228b22",
-    "#ff00ff",
-    "#dcdcdc",
-    "#f8f8ff",
-    "#ffd700",
-    "#daa520",
-    "#808080",
-    "#008000",
-    "#adff2f",
-    "#808080",
-    "#f0fff0",
-    "#ff69b4",
-    "#cd5c5c",
-    "#4b0082",
-    "#fffff0",
-    "#f0e68c",
-    "#e6e6fa",
-    "#fff0f5",
-    "#7cfc00",
-    "#fffacd",
-    "#add8e6",
-    "#f08080",
-    "#e0ffff",
-    "#fafad2",
-    "#d3d3d3",
-    "#90ee90",
-    "#d3d3d3",
-    "#ffb6c1",
-    "#ffa07a",
-    "#20b2aa",
-    "#87cefa",
-    "#778899",
-    "#778899",
-    "#b0c4de",
-    "#ffffe0",
-    "#00ff00",
-    "#32cd32",
-    "#faf0e6",
-    "#ff00ff",
-    "#800000",
-    "#66cdaa",
-    "#0000cd",
-    "#ba55d3",
-    "#9370db",
-    "#3cb371",
-    "#7b68ee",
-    "#00fa9a",
-    "#48d1cc",
-    "#c71585",
-    "#191970",
-    "#f5fffa",
-    "#ffe4e1",
-    "#ffe4b5",
-    "#ffdead",
-    "#000080",
-    "#fdf5e6",
-    "#808000",
-    "#6b8e23",
-    "#ffa500",
-    "#ff4500",
-    "#da70d6",
-    "#eee8aa",
-    "#98fb98",
-    "#afeeee",
-    "#db7093",
-    "#ffefd5",
-    "#ffdab9",
-    "#cd853f",
-    "#ffc0cb",
-    "#dda0dd",
-    "#b0e0e6",
-    "#800080",
-    "#663399",
-    "#ff0000",
-    "#bc8f8f",
-    "#4169e1",
-    "#8b4513",
-    "#fa8072",
-    "#f4a460",
-    "#2e8b57",
-    "#fff5ee",
-    "#a0522d",
-    "#c0c0c0",
-    "#87ceeb",
-    "#6a5acd",
-    "#708090",
-    "#708090",
-    "#fffafa",
-    "#00ff7f",
-    "#4682b4",
-    "#d2b48c",
-    "#008080",
-    "#d8bfd8",
-    "#ff6347",
-    "#40e0d0",
-    "#ee82ee",
-    "#f5deb3",
-    "#ffffff",
-    "#f5f5f5",
-    "#ffff00",
-    "#9acd32",
+    "#f0f8ff", "#faebd7", "#00ffff", "#7fffd4", "#f0ffff", "#f5f5dc", "#ffe4c4", "#000000",
+    "#ffebcd", "#0000ff", "#8a2be2", "#a52a2a", "#deb887", "#5f9ea0", "#7fff00", "#d2691e",
+    "#ff7f50", "#6495ed", "#fff8dc", "#dc143c", "#00ffff", "#00008b", "#008b8b", "#b8860b",
+    "#a9a9a9", "#006400", "#a9a9a9", "#bdb76b", "#8b008b", "#556b2f", "#ff8c00", "#9932cc",
+    "#8b0000", "#e9967a", "#8fbc8f", "#483d8b", "#2f4f4f", "#2f4f4f", "#00ced1", "#9400d3",
+    "#ff1493", "#00bfff", "#696969", "#696969", "#1e90ff", "#b22222", "#fffaf0", "#228b22",
+    "#ff00ff", "#dcdcdc", "#f8f8ff", "#ffd700", "#daa520", "#808080", "#008000", "#adff2f",
+    "#808080", "#f0fff0", "#ff69b4", "#cd5c5c", "#4b0082", "#fffff0", "#f0e68c", "#e6e6fa",
+    "#fff0f5", "#7cfc00", "#fffacd", "#add8e6", "#f08080", "#e0ffff", "#fafad2", "#d3d3d3",
+    "#90ee90", "#d3d3d3", "#ffb6c1", "#ffa07a", "#20b2aa", "#87cefa", "#778899", "#778899",
+    "#b0c4de", "#ffffe0", "#00ff00", "#32cd32", "#faf0e6", "#ff00ff", "#800000", "#66cdaa",
+    "#0000cd", "#ba55d3", "#9370db", "#3cb371", "#7b68ee", "#00fa9a", "#48d1cc", "#c71585",
+    "#191970", "#f5fffa", "#ffe4e1", "#ffe4b5", "#ffdead", "#000080", "#fdf5e6", "#808000",
+    "#6b8e23", "#ffa500", "#ff4500", "#da70d6", "#eee8aa", "#98fb98", "#afeeee", "#db7093",
+    "#ffefd5", "#ffdab9", "#cd853f", "#ffc0cb", "#dda0dd", "#b0e0e6", "#800080", "#663399",
+    "#ff0000", "#bc8f8f", "#4169e1", "#8b4513", "#fa8072", "#f4a460", "#2e8b57", "#fff5ee",
+    "#a0522d", "#c0c0c0", "#87ceeb", "#6a5acd", "#708090", "#708090", "#fffafa", "#00ff7f",
+    "#4682b4", "#d2b48c", "#008080", "#d8bfd8", "#ff6347", "#40e0d0", "#ee82ee", "#f5deb3",
+    "#ffffff", "#f5f5f5", "#ffff00", "#9acd32",
 ];

--- a/src/coord.rs
+++ b/src/coord.rs
@@ -2,9 +2,9 @@
 //! math in 3 dimensions with scalars and other coordinates. Used to unify math with colors that is
 //! the same, just with different projections into 3D space.
 
-use std::ops::{Add, Div, Mul, Sub};
 use num;
 use num::{Num, NumCast};
+use std::ops::{Add, Div, Mul, Sub};
 
 /// Represents a scalar value that can be easily converted, described using the common numeric traits
 /// in [`num`]. Anything that falls under this category can be multiplied by a [`Coord`] to scale

--- a/src/cssnumeric.rs
+++ b/src/cssnumeric.rs
@@ -3,14 +3,14 @@
 //! encode arbitrary CSS color descriptions into Scarlet structs. (Source for CSS syntax:
 //! [https://www.w3.org/TR/css-color-3/](https://www.w3.org/TR/css-color-3/).)
 
-use std::fmt;
 use std::error::Error;
+use std::fmt;
 
 /// A CSS numeric value. Either an integer, like 255, a float, like 0.8, or a percentage, like
 /// 104%.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub(crate) enum CSSNumeric {
-    /// Represents a string of numeric tokens, such as "124", with an optional leading '+' or '-'. 
+    /// Represents a string of numeric tokens, such as "124", with an optional leading '+' or '-'.
     Integer(isize),
     /// Represents two integers separated by a '.', such that the second integer has no leading sign.
     Float(f64),
@@ -48,8 +48,6 @@ impl Error for CSSParseError {
     }
 }
 
-
-
 /// Parses a prechecked integer without a sign, such as "023" or "142". Panics on invalid input.
 fn parse_css_integer(num: &str) -> u64 {
     num.parse().unwrap()
@@ -67,7 +65,7 @@ pub(crate) fn parse_css_number(num: &str) -> Result<CSSNumeric, CSSParseError> {
     let mut chars: Vec<char> = num.chars().collect();
     // if invalid characters, return appropriate error
     if !chars.iter().all(|&c| "0123456789-+.%".contains(c)) {
-        return Err(CSSParseError::InvalidNumericCharacters)
+        return Err(CSSParseError::InvalidNumericCharacters);
     }
     // test if initial character is '-' or '+'. Remove and set sign flag accordingly.
     let is_positive = match chars[0] {
@@ -80,11 +78,11 @@ pub(crate) fn parse_css_number(num: &str) -> Result<CSSNumeric, CSSParseError> {
     }
     // if no longer any characters, throw error
     if chars.is_empty() {
-        return Err(CSSParseError::InvalidNumericSyntax)
+        return Err(CSSParseError::InvalidNumericSyntax);
     }
     // if any other pluses or minuses, throw error
     if chars.iter().any(|&c| "-=".contains(c)) {
-        return Err(CSSParseError::InvalidNumericSyntax)
+        return Err(CSSParseError::InvalidNumericSyntax);
     }
     // Test if number contains exactly one period. If more than one, throw error: otherwise, split to
     // cases.
@@ -106,7 +104,7 @@ pub(crate) fn parse_css_number(num: &str) -> Result<CSSNumeric, CSSParseError> {
                 1 => {
                     // check if % is at end
                     if chars.iter().last().unwrap() == &'%' {
-                        // parse the rest as integer and return                        
+                        // parse the rest as integer and return
                         chars.pop();
                         let uint = parse_css_integer(&(chars.iter().collect::<String>()));
                         // adjust for sign
@@ -130,11 +128,7 @@ pub(crate) fn parse_css_number(num: &str) -> Result<CSSNumeric, CSSParseError> {
         1 => {
             // parse as valid float and account for sign
             let ufloat = parse_css_float(&(chars.iter().collect::<String>()));
-            let float = if is_positive {
-                ufloat
-            } else {
-                -ufloat
-            };
+            let float = if is_positive { ufloat } else { -ufloat };
             Ok(CSSNumeric::Float(float))
         }
         _ => {
@@ -142,8 +136,7 @@ pub(crate) fn parse_css_number(num: &str) -> Result<CSSNumeric, CSSParseError> {
             Err(CSSParseError::InvalidNumericSyntax)
         }
     }
-}       
-
+}
 
 #[cfg(test)]
 mod tests {
@@ -232,11 +225,23 @@ mod tests {
     #[test]
     fn test_errors() {
         // test non-numeric characters
-        assert_eq!(parse_css_number("abc"), Err(CSSParseError::InvalidNumericCharacters));
+        assert_eq!(
+            parse_css_number("abc"),
+            Err(CSSParseError::InvalidNumericCharacters)
+        );
         // test multiple periods
-        assert_eq!(parse_css_number("14.23.2"), Err(CSSParseError::InvalidNumericSyntax));
+        assert_eq!(
+            parse_css_number("14.23.2"),
+            Err(CSSParseError::InvalidNumericSyntax)
+        );
         // test multiple percentages, percentages in wrong place
-        assert_eq!(parse_css_number("-24%%"), Err(CSSParseError::InvalidNumericSyntax));
-        assert_eq!(parse_css_number("1%2%"), Err(CSSParseError::InvalidNumericSyntax));        
+        assert_eq!(
+            parse_css_number("-24%%"),
+            Err(CSSParseError::InvalidNumericSyntax)
+        );
+        assert_eq!(
+            parse_css_number("1%2%"),
+            Err(CSSParseError::InvalidNumericSyntax)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! anything else.
 
 #![doc(html_root_url = "https://docs.rs/scarlet/1.0.2")]
-
 // we don't mess around with documentation
 #![deny(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::lint_name))]
@@ -23,27 +22,24 @@ extern crate num;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate termion;
 #[macro_use]
 extern crate lazy_static;
 
-pub mod coord;
-mod consts;
-mod matplotlib_cmaps;
-mod cssnumeric;
-mod csscolor;
-pub mod illuminants;
-pub mod color;
 pub mod bound;
-mod visual_gamut;
-pub mod colors;
-pub mod colorpoint;
+pub mod color;
 pub mod colormap;
+pub mod colorpoint;
+pub mod colors;
+mod consts;
+pub mod coord;
+mod csscolor;
+mod cssnumeric;
+pub mod illuminants;
 pub mod material_colors;
+mod matplotlib_cmaps;
 pub mod prelude;
+mod visual_gamut;
 // pub mod doc;
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/material_colors.rs
+++ b/src/material_colors.rs
@@ -9,7 +9,6 @@
 
 use color::RGBColor;
 
-
 /// A neutral tint or shade of a given Material Design hue. Although the values are usually given as
 /// numerical literals, numerical literals are not valid identifiers.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
@@ -37,7 +36,6 @@ pub enum AccentTone {
     A700,
 }
 
-
 /// Either a neutral or accent tone, with a prefix to distinguish them.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum MaterialTone {
@@ -50,31 +48,26 @@ pub enum MaterialTone {
 // Gets the index in the list returned by the hashmap corresponding to the given tone.
 fn to_index(tone: MaterialTone) -> usize {
     match tone {
-        MaterialTone::Neutral(w) => {
-            match w {
-                NeutralTone::W500 => 0,
-                NeutralTone::W50 => 1,
-                NeutralTone::W100 => 2,
-                NeutralTone::W200 => 3,
-                NeutralTone::W300 => 4,
-                NeutralTone::W400 => 5,
-                NeutralTone::W600 => 6,
-                NeutralTone::W700 => 7,
-                NeutralTone::W800 => 8,
-                NeutralTone::W900 => 9,
-            }
-        }
-        MaterialTone::Accent(a) => {
-            match a {
-                AccentTone::A100 => 10,
-                AccentTone::A200 => 11,
-                AccentTone::A400 => 12,
-                AccentTone::A700 => 13,
-            }
-        }
+        MaterialTone::Neutral(w) => match w {
+            NeutralTone::W500 => 0,
+            NeutralTone::W50 => 1,
+            NeutralTone::W100 => 2,
+            NeutralTone::W200 => 3,
+            NeutralTone::W300 => 4,
+            NeutralTone::W400 => 5,
+            NeutralTone::W600 => 6,
+            NeutralTone::W700 => 7,
+            NeutralTone::W800 => 8,
+            NeutralTone::W900 => 9,
+        },
+        MaterialTone::Accent(a) => match a {
+            AccentTone::A100 => 10,
+            AccentTone::A200 => 11,
+            AccentTone::A400 => 12,
+            AccentTone::A700 => 13,
+        },
     }
 }
-
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 /// A fully specified Material color. Note that, depending on whether the color has accent tones,
@@ -106,304 +99,84 @@ pub enum MaterialPrimary {
     White,
 }
 
-
-
 // values copied from material-palette.csv, which is in turn copied from the Material Design
 // Photoshop palette
 const RED_COLORS: [&str; 14] = [
-    "#f44336",
-    "#ffebee",
-    "#ffcdd2",
-    "#ef9a9a",
-    "#e57373",
-    "#ef5350",
-    "#e53935",
-    "#d32f2f",
-    "#c62828",
-    "#b71c1c",
-    "#ff8a80",
-    "#ff5252",
-    "#ff1744",
-    "#d50000",
+    "#f44336", "#ffebee", "#ffcdd2", "#ef9a9a", "#e57373", "#ef5350", "#e53935", "#d32f2f",
+    "#c62828", "#b71c1c", "#ff8a80", "#ff5252", "#ff1744", "#d50000",
 ];
 const PINK_COLORS: [&str; 14] = [
-    "#e91e63",
-    "#fce4ec",
-    "#f8bbd0",
-    "#f48fb1",
-    "#f06292",
-    "#ec407a",
-    "#d81b60",
-    "#c2185b",
-    "#ad1457",
-    "#880e4f",
-    "#ff80ab",
-    "#ff4081",
-    "#f50057",
-    "#c51162",
+    "#e91e63", "#fce4ec", "#f8bbd0", "#f48fb1", "#f06292", "#ec407a", "#d81b60", "#c2185b",
+    "#ad1457", "#880e4f", "#ff80ab", "#ff4081", "#f50057", "#c51162",
 ];
 const PURPLE_COLORS: [&str; 14] = [
-    "#9c27b0",
-    "#f3e5f5",
-    "#e1bee7",
-    "#ce93d8",
-    "#ba68c8",
-    "#ab47bc",
-    "#8e24aa",
-    "#7b1fa2",
-    "#6a1b9a",
-    "#4a148c",
-    "#ea80fc",
-    "#e040fb",
-    "#d500f9",
-    "#aa00ff",
+    "#9c27b0", "#f3e5f5", "#e1bee7", "#ce93d8", "#ba68c8", "#ab47bc", "#8e24aa", "#7b1fa2",
+    "#6a1b9a", "#4a148c", "#ea80fc", "#e040fb", "#d500f9", "#aa00ff",
 ];
 const DEEP_PURPLE_COLORS: [&str; 14] = [
-    "#673ab7",
-    "#ede7f6",
-    "#d1c4e9",
-    "#b39ddb",
-    "#9575cd",
-    "#7e57c2",
-    "#5e35b1",
-    "#512da8",
-    "#4527a0",
-    "#311b92",
-    "#b388ff",
-    "#7c4dff",
-    "#651fff",
-    "#6200ea",
+    "#673ab7", "#ede7f6", "#d1c4e9", "#b39ddb", "#9575cd", "#7e57c2", "#5e35b1", "#512da8",
+    "#4527a0", "#311b92", "#b388ff", "#7c4dff", "#651fff", "#6200ea",
 ];
 const INDIGO_COLORS: [&str; 14] = [
-    "#3f51b5",
-    "#e8eaf6",
-    "#c5cae9",
-    "#9fa8da",
-    "#7986cb",
-    "#5c6bc0",
-    "#3949ab",
-    "#303f9f",
-    "#283593",
-    "#1a237e",
-    "#8c9eff",
-    "#536dfe",
-    "#3d5afe",
-    "#304ffe",
+    "#3f51b5", "#e8eaf6", "#c5cae9", "#9fa8da", "#7986cb", "#5c6bc0", "#3949ab", "#303f9f",
+    "#283593", "#1a237e", "#8c9eff", "#536dfe", "#3d5afe", "#304ffe",
 ];
 const BLUE_COLORS: [&str; 14] = [
-    "#2196f3",
-    "#e3f2fd",
-    "#bbdefb",
-    "#90caf9",
-    "#64b5f6",
-    "#42a5f5",
-    "#1e88e5",
-    "#1976d2",
-    "#1565c0",
-    "#0d47a1",
-    "#82b1ff",
-    "#448aff",
-    "#2979ff",
-    "#2962ff",
+    "#2196f3", "#e3f2fd", "#bbdefb", "#90caf9", "#64b5f6", "#42a5f5", "#1e88e5", "#1976d2",
+    "#1565c0", "#0d47a1", "#82b1ff", "#448aff", "#2979ff", "#2962ff",
 ];
 const LIGHT_BLUE_COLORS: [&str; 14] = [
-    "#03a9f4",
-    "#e1f5fe",
-    "#b3e5fc",
-    "#81d4fa",
-    "#4fc3f7",
-    "#29b6f6",
-    "#039be5",
-    "#0288d1",
-    "#0277bd",
-    "#01579b",
-    "#80d8ff",
-    "#40c4ff",
-    "#00b0ff",
-    "#0091ea",
+    "#03a9f4", "#e1f5fe", "#b3e5fc", "#81d4fa", "#4fc3f7", "#29b6f6", "#039be5", "#0288d1",
+    "#0277bd", "#01579b", "#80d8ff", "#40c4ff", "#00b0ff", "#0091ea",
 ];
 const CYAN_COLORS: [&str; 14] = [
-    "#00bcd4",
-    "#e0f7fa",
-    "#b2ebf2",
-    "#80deea",
-    "#4dd0e1",
-    "#26c6da",
-    "#00acc1",
-    "#0097a7",
-    "#00838f",
-    "#006064",
-    "#84ffff",
-    "#18ffff",
-    "#00e5ff",
-    "#00b8d4",
+    "#00bcd4", "#e0f7fa", "#b2ebf2", "#80deea", "#4dd0e1", "#26c6da", "#00acc1", "#0097a7",
+    "#00838f", "#006064", "#84ffff", "#18ffff", "#00e5ff", "#00b8d4",
 ];
 const TEAL_COLORS: [&str; 14] = [
-    "#009688",
-    "#e0f2f1",
-    "#b2dfdb",
-    "#80cbc4",
-    "#4db6ac",
-    "#26a69a",
-    "#00897b",
-    "#00796b",
-    "#00695c",
-    "#004d40",
-    "#a7ffeb",
-    "#64ffda",
-    "#1de9b6",
-    "#00bfa5",
+    "#009688", "#e0f2f1", "#b2dfdb", "#80cbc4", "#4db6ac", "#26a69a", "#00897b", "#00796b",
+    "#00695c", "#004d40", "#a7ffeb", "#64ffda", "#1de9b6", "#00bfa5",
 ];
 const GREEN_COLORS: [&str; 14] = [
-    "#4caf50",
-    "#e8f5e9",
-    "#c8e6c9",
-    "#a5d6a7",
-    "#81c784",
-    "#66bb6a",
-    "#43a047",
-    "#388e3c",
-    "#2e7d32",
-    "#1b5e20",
-    "#b9f6ca",
-    "#69f0ae",
-    "#00e676",
-    "#00c853",
+    "#4caf50", "#e8f5e9", "#c8e6c9", "#a5d6a7", "#81c784", "#66bb6a", "#43a047", "#388e3c",
+    "#2e7d32", "#1b5e20", "#b9f6ca", "#69f0ae", "#00e676", "#00c853",
 ];
 const LIGHT_GREEN_COLORS: [&str; 14] = [
-    "#8bc34a",
-    "#f1f8e9",
-    "#dcedc8",
-    "#c5e1a5",
-    "#aed581",
-    "#9ccc65",
-    "#7cb342",
-    "#689f38",
-    "#558b2f",
-    "#33691e",
-    "#ccff90",
-    "#b2ff59",
-    "#76ff03",
-    "#64dd17",
+    "#8bc34a", "#f1f8e9", "#dcedc8", "#c5e1a5", "#aed581", "#9ccc65", "#7cb342", "#689f38",
+    "#558b2f", "#33691e", "#ccff90", "#b2ff59", "#76ff03", "#64dd17",
 ];
 const LIME_COLORS: [&str; 14] = [
-    "#cddc39",
-    "#f9fbe7",
-    "#f0f4c3",
-    "#e6ee9c",
-    "#dce775",
-    "#d4e157",
-    "#c0ca33",
-    "#afb42b",
-    "#9e9d24",
-    "#827717",
-    "#f4ff81",
-    "#eeff41",
-    "#c6ff00",
-    "#aeea00",
+    "#cddc39", "#f9fbe7", "#f0f4c3", "#e6ee9c", "#dce775", "#d4e157", "#c0ca33", "#afb42b",
+    "#9e9d24", "#827717", "#f4ff81", "#eeff41", "#c6ff00", "#aeea00",
 ];
 const YELLOW_COLORS: [&str; 14] = [
-    "#ffeb3b",
-    "#fffde7",
-    "#fff9c4",
-    "#fff59d",
-    "#fff176",
-    "#ffee58",
-    "#fdd835",
-    "#fbc02d",
-    "#f9a825",
-    "#f57f17",
-    "#ffff8d",
-    "#ffff00",
-    "#ffea00",
-    "#ffd600",
+    "#ffeb3b", "#fffde7", "#fff9c4", "#fff59d", "#fff176", "#ffee58", "#fdd835", "#fbc02d",
+    "#f9a825", "#f57f17", "#ffff8d", "#ffff00", "#ffea00", "#ffd600",
 ];
 const AMBER_COLORS: [&str; 14] = [
-    "#ffc107",
-    "#fff8e1",
-    "#ffecb3",
-    "#ffe082",
-    "#ffd54f",
-    "#ffca28",
-    "#ffb300",
-    "#ffa000",
-    "#ff8f00",
-    "#ff6f00",
-    "#ffe57f",
-    "#ffd740",
-    "#ffc400",
-    "#ffab00",
+    "#ffc107", "#fff8e1", "#ffecb3", "#ffe082", "#ffd54f", "#ffca28", "#ffb300", "#ffa000",
+    "#ff8f00", "#ff6f00", "#ffe57f", "#ffd740", "#ffc400", "#ffab00",
 ];
 const ORANGE_COLORS: [&str; 14] = [
-    "#ff9800",
-    "#fff3e0",
-    "#ffe0b2",
-    "#ffcc80",
-    "#ffb74d",
-    "#ffa726",
-    "#fb8c00",
-    "#f57c00",
-    "#ef6c00",
-    "#e65100",
-    "#ffd180",
-    "#ffab40",
-    "#ff9100",
-    "#ff6d00",
+    "#ff9800", "#fff3e0", "#ffe0b2", "#ffcc80", "#ffb74d", "#ffa726", "#fb8c00", "#f57c00",
+    "#ef6c00", "#e65100", "#ffd180", "#ffab40", "#ff9100", "#ff6d00",
 ];
 const DEEP_ORANGE_COLORS: [&str; 14] = [
-    "#ff5722",
-    "#fbe9e7",
-    "#ffccbc",
-    "#ffab91",
-    "#ff8a65",
-    "#ff7043",
-    "#f4511e",
-    "#e64a19",
-    "#d84315",
-    "#bf360c",
-    "#ff9e80",
-    "#ff6e40",
-    "#ff3d00",
-    "#dd2c00",
+    "#ff5722", "#fbe9e7", "#ffccbc", "#ffab91", "#ff8a65", "#ff7043", "#f4511e", "#e64a19",
+    "#d84315", "#bf360c", "#ff9e80", "#ff6e40", "#ff3d00", "#dd2c00",
 ];
 const GREY_COLORS: [&str; 10] = [
-    "#9e9e9e",
-    "#fafafa",
-    "#f5f5f5",
-    "#eeeeee",
-    "#e0e0e0",
-    "#bdbdbd",
-    "#757575",
-    "#616161",
-    "#424242",
-    "#212121",
+    "#9e9e9e", "#fafafa", "#f5f5f5", "#eeeeee", "#e0e0e0", "#bdbdbd", "#757575", "#616161",
+    "#424242", "#212121",
 ];
 const BLUE_GREY_COLORS: [&str; 10] = [
-    "#607d8b",
-    "#eceff1",
-    "#cfd8dc",
-    "#b0bec5",
-    "#90a4ae",
-    "#78909c",
-    "#546e7a",
-    "#455a64",
-    "#37474f",
-    "#263238",
+    "#607d8b", "#eceff1", "#cfd8dc", "#b0bec5", "#90a4ae", "#78909c", "#546e7a", "#455a64",
+    "#37474f", "#263238",
 ];
 const BROWN_COLORS: [&str; 10] = [
-    "#795548",
-    "#efebe9",
-    "#d7ccc8",
-    "#bcaaa4",
-    "#a1887f",
-    "#8d6e63",
-    "#6d4c41",
-    "#5d4037",
-    "#4e342e",
-    "#3e2723",
+    "#795548", "#efebe9", "#d7ccc8", "#bcaaa4", "#a1887f", "#8d6e63", "#6d4c41", "#5d4037",
+    "#4e342e", "#3e2723",
 ];
-
-
 
 impl RGBColor {
     /// Gets a Color from the Material palette, given a specification of such a color.
@@ -449,7 +222,6 @@ impl RGBColor {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
@@ -486,7 +258,7 @@ mod tests {
             "#4CAF50"
         );
     }
-    
+
     #[test]
     #[ignore]
     fn test_equalized_scheme() {
@@ -499,7 +271,10 @@ mod tests {
         let blue = MaterialPrimary::Blue(MaterialTone::Neutral(NeutralTone::W400));
         let purple_d = MaterialPrimary::DeepPurple(MaterialTone::Neutral(NeutralTone::W400));
         let prims = vec![red, orange, orange_d, yellow, green, blue_l, blue, purple_d];
-        let cols: Vec<RGBColor> = prims.iter().map(|x| RGBColor::from_material_palette(*x)).collect();
+        let cols: Vec<RGBColor> = prims
+            .iter()
+            .map(|x| RGBColor::from_material_palette(*x))
+            .collect();
         let mean_l = cols.iter().map(|x| x.lightness()).sum::<f64>() / 8.;
         for mut col in cols {
             col.set_lightness(mean_l);
@@ -507,4 +282,3 @@ mod tests {
         }
     }
 }
-


### PR DESCRIPTION
The dependency on termion makes it so that scarlet cannot be compiled targeting web assembly.
I'm not super familiar with the reasons why that's the case or how one could work around that limitation, but this didn't seem to be necessary as that code seemed to be used mostly in ignored unit tests.
I've removed the dependency, the methods that were using it and reformatted the code with `cargo fmt`.
Snippet with error output from `wasm-pack`:
```
error[E0433]: failed to resolve: maybe a missing crate `sys`?
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/lib.rs:24:9
   |
24 | pub use sys::size::terminal_size;
   |         ^^^ maybe a missing crate `sys`?

error[E0433]: failed to resolve: maybe a missing crate `sys`?
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/lib.rs:27:9
   |
27 | pub use sys::tty::{is_tty, get_tty};
   |         ^^^ maybe a missing crate `sys`?

error[E0433]: failed to resolve: maybe a missing crate `sys`?
 --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/async.rs:5:5
  |
5 | use sys::tty::get_tty;
  |     ^^^ maybe a missing crate `sys`?

error[E0433]: failed to resolve: maybe a missing crate `sys`?
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:29:5
   |
29 | use sys::attr::{get_terminal_attr, raw_terminal_attr, set_terminal_attr};
   |     ^^^ maybe a missing crate `sys`?

error[E0432]: unresolved import `sys`
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:28:5
   |
28 | use sys::Termios;
   |     ^^^ maybe a missing crate `sys`?

error[E0425]: cannot find function `get_tty` in this scope
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/async.rs:14:36
   |
14 |     thread::spawn(move || for i in get_tty().unwrap().bytes() {
   |                                    ^^^^^^^ not found in this scope

error[E0425]: cannot find function `get_tty` in this scope
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/async.rs:43:36
   |
43 |     thread::spawn(move || for i in get_tty().unwrap().bytes() {
   |                                    ^^^^^^^ not found in this scope

error[E0425]: cannot find function `set_terminal_attr` in this scope
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:45:9
   |
45 |         set_terminal_attr(&self.prev_ios).unwrap();
   |         ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `get_terminal_attr` in this scope
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:90:23
   |
90 |         let mut ios = get_terminal_attr()?;
   |                       ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `raw_terminal_attr` in this scope
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:93:9
   |
93 |         raw_terminal_attr(&mut ios);
   |         ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `set_terminal_attr` in this scope
  --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:95:9
   |
95 |         set_terminal_attr(&ios)?;
   |         ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `set_terminal_attr` in this scope
   --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:107:9
    |
107 |         set_terminal_attr(&self.prev_ios)?;
    |         ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `get_terminal_attr` in this scope
   --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:113:23
    |
113 |         let mut ios = get_terminal_attr()?;
    |                       ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `raw_terminal_attr` in this scope
   --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:114:9
    |
114 |         raw_terminal_attr(&mut ios);
    |         ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `set_terminal_attr` in this scope
   --> /Users/felipecsl/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.5/src/raw.rs:115:9
    |
115 |         set_terminal_attr(&ios)?;
    |         ^^^^^^^^^^^^^^^^^ not found in this scope

error: aborting due to 15 previous errors
```