### PR TITLE
fix warnings & update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ terminal = ["termion"]
 
 
 [dependencies]
-regex = "1.3.6"
-num = "0.2.1"
-float-cmp = "0.6.0"
-csv = "1.1.3"
-serde = "1.0.106"
-serde_derive = "1.0.106"
-geo = "0.13.0"
+regex = "1.4.3"
+num = "0.3.1"
+float-cmp = "0.8.0"
+csv = "1.1.5"
+serde = "1.0.120"
+serde_derive = "1.0.120"
+geo = "0.17.0"
 rulinalg = "0.4.2"
 maplit = "1.0.2"
 lazy_static = "1.4.0"

--- a/src/color.rs
+++ b/src/color.rs
@@ -198,9 +198,9 @@ impl XYZColor {
     ///
     /// [`Color::visually_indistinguishable`]: ../color/trait.Color.html#method.visually_indistinguishable
     pub fn approx_equal(&self, other: &XYZColor) -> bool {
-        ((self.x - other.x).abs() <= 1e-15
+        (self.x - other.x).abs() <= 1e-15
             && (self.y - other.y).abs() <= 1e-15
-            && (self.z - other.z).abs() <= 1e-15)
+            && (self.z - other.z).abs() <= 1e-15
     }
 
     /// Returns `true` if the given other XYZ color would look identically in a different color

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,33 +16,38 @@ use rulinalg::matrix::Matrix;
 
 lazy_static! {
     pub(crate) static ref ADOBE_RGB_TRANSFORM: Matrix<f64> = {
+        // FIXME: https://github.com/rust-lang/rust/issues/66145
+        // warning: this method call currently resolves to
+        // `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions),
+        // but that might change in the future when `IntoIterator` impls for
+        // arrays are added.
         matrix![02.04159, -0.56501, -0.34473;
                 -0.96924, 01.87957, 00.04156;
                 00.01344, -0.11836, 01.01517]
     };
     pub(crate) static ref ADOBE_RGB_TRANSFORM_LU: PartialPivLu<f64> =
-        { PartialPivLu::decompose(ADOBE_RGB_TRANSFORM.clone()).expect("Matrix is invertible.") };
+        PartialPivLu::decompose(ADOBE_RGB_TRANSFORM.clone()).expect("Matrix is invertible.");
     pub(crate) static ref BRADFORD_TRANSFORM: Matrix<f64> = {
         matrix![00.8951, 00.2664, -0.1614;
                 -0.7502, 01.7135, 00.0367;
                 00.0389, -0.0685, 01.0296]
     };
     pub(crate) static ref BRADFORD_TRANSFORM_LU: PartialPivLu<f64> =
-        { PartialPivLu::decompose(BRADFORD_TRANSFORM.clone()).expect("Matrix is invertible.") };
+        PartialPivLu::decompose(BRADFORD_TRANSFORM.clone()).expect("Matrix is invertible.");
     pub(crate) static ref ROMM_RGB_TRANSFORM: Matrix<f64> = {
         matrix![0.7976749, 0.1351917, 0.0313534;
                 0.2880402, 0.7118741, 0.0000857;
                 0.0000000, 0.0000000, 0.8252100]
     };
     pub(crate) static ref ROMM_RGB_TRANSFORM_LU: PartialPivLu<f64> =
-        { PartialPivLu::decompose(ROMM_RGB_TRANSFORM.clone()).expect("Matrix is invertible.") };
+        PartialPivLu::decompose(ROMM_RGB_TRANSFORM.clone()).expect("Matrix is invertible.");
     pub(crate) static ref STANDARD_RGB_TRANSFORM: Matrix<f64> = {
         matrix![03.2406, -1.5372, -0.4986;
                 -0.9689, 01.8758, 00.0415;
                 00.0557, -0.2040, 01.0570]
     };
     pub(crate) static ref STANDARD_RGB_TRANSFORM_LU: PartialPivLu<f64> =
-        { PartialPivLu::decompose(STANDARD_RGB_TRANSFORM.clone()).expect("Matrix is invertible.") };
+        PartialPivLu::decompose(STANDARD_RGB_TRANSFORM.clone()).expect("Matrix is invertible.");
 }
 
 // These next two constants define the X11 color names and hex codes.

--- a/src/visual_gamut.rs
+++ b/src/visual_gamut.rs
@@ -5,7 +5,6 @@ use illuminants::Illuminant;
 
 use super::csv;
 
-use std::error::Error;
 use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,7 +21,7 @@ pub fn read_cie_spectral_data() -> (Vec<u16>, Vec<XYZColor>) {
     let mut xyz_data = vec![];
     let path = Path::new("cie-1931-standard-matching.csv");
     let mut reader = match csv::Reader::from_path(path) {
-        Err(e) => panic!("CIE spectral data could not be read: {}", e.description()),
+        Err(e) => panic!("CIE spectral data could not be read: {}", e.to_string()),
         Ok(rdr) => rdr,
     };
     for result in reader.deserialize() {


### PR DESCRIPTION
- fix unneeded parenthesis & brackets.
- fix deprecated function.
- fix unused import.
- add FIXME comment for remaining non-fixed warnings.
- update outdated dependencies.