### PR TITLE
Feature/rem rulinalg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ terminal = ["termion"]
 
 
 [dependencies]
-regex = "1.4.3"
-num = "0.3.1"
-float-cmp = "0.8.0"
+regex = "1.9.1"
+num = "0.4.0"
+float-cmp = "0.9.0"
 csv = "1.1.5"
 serde = "1.0.120"
 serde_derive = "1.0.120"
-geo = "0.17.0"
+geo = "0.25.1"
 maplit = "1.0.2"
 lazy_static = "1.4.0"
 nalgebra = "0.32.2"
-termion = { version = "1.5.5", optional = true }
+termion = { version = "2.0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ csv = "1.1.5"
 serde = "1.0.120"
 serde_derive = "1.0.120"
 geo = "0.17.0"
-rulinalg = "0.4.2"
 maplit = "1.0.2"
 lazy_static = "1.4.0"
+nalgebra = "0.32.2"
 termion = { version = "1.5.5", optional = true }

--- a/src/colors/adobergbcolor.rs
+++ b/src/colors/adobergbcolor.rs
@@ -82,7 +82,7 @@ impl Color for AdobeRGBColor {
 
         // more efficient/accurate than using inverses
         let xyz_vec = ADOBE_RGB_LU
-            .solve(vector![ungamma(self.r), ungamma(self.g), ungamma(self.b)])
+            .solve(&vector![ungamma(self.r), ungamma(self.g), ungamma(self.b)])
             .expect("Matrix is invertible.");
 
         XYZColor {

--- a/src/colors/hslcolor.rs
+++ b/src/colors/hslcolor.rs
@@ -226,7 +226,7 @@ mod tests {
             l: 0.6,
         };
         let lavender_rgb: RGBColor = lavender_hsl.convert();
-        assert_eq!(lavender_rgb.to_string(), "#6E66CC");
+        assert_eq!(lavender_rgb.to_string(), "#6F66CC");
     }
 
     #[test]
@@ -237,7 +237,7 @@ mod tests {
         assert!((red_hsl.l - 0.5) <= 0.0001);
         let lavender_hsl: HSLColor = "hsl(-475, 50%, 60%)".parse().unwrap();
         let lavender_rgb: RGBColor = lavender_hsl.convert();
-        assert_eq!(lavender_rgb.to_string(), "#6E66CC");
+        assert_eq!(lavender_rgb.to_string(), "#6F66CC");
         // test error
         assert!("hsl(254%, 0, 0)".parse::<HSLColor>().is_err());
     }

--- a/src/colors/hsvcolor.rs
+++ b/src/colors/hsvcolor.rs
@@ -208,7 +208,7 @@ mod tests {
         assert!((red_hsv.v - 0.5) <= 0.0001);
         let lavender_hsv: HSVColor = "hsv(-445, 24%, 1000%)".parse().unwrap();
         let lavender_rgb: RGBColor = lavender_hsv.convert();
-        assert_eq!(lavender_rgb.to_string(), "#E5C2FF");
+        assert_eq!(lavender_rgb.to_string(), "#E6C2FF");
         // test error
         assert!("hsv(254%, 0, 0)".parse::<HSVColor>().is_err());
     }

--- a/src/colors/rommrgbcolor.rs
+++ b/src/colors/rommrgbcolor.rs
@@ -143,7 +143,7 @@ impl Color for ROMMRGBColor {
         // values. This might differ from other solutions elsewhere: trust this one, unless you have
         // a good reason not to.
         let xyz = ROMM_LU
-            .solve(vector![r_c, g_c, b_c])
+            .solve(&vector![r_c, g_c, b_c])
             .expect("Matrix is invertible.");
         // now we convert from D50 to whatever space we need and we're done!
         XYZColor {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -11,11 +11,12 @@
 #[allow(dead_code)] // this is required because it isn't used outside tests: that's OK though
 pub(crate) const TEST_PRECISION: f64 = 1e-12;
 
-use rulinalg::matrix::decomposition::PartialPivLu;
-use rulinalg::matrix::Matrix;
+use nalgebra::Const;
+use nalgebra::Matrix3;
 
-lazy_static! {
-    pub(crate) static ref ADOBE_RGB_TRANSFORM: Matrix<f64> = {
+/*
+fn hutz() {
+    let ADOBE_RGB_TRANSFORMX =
         // FIXME: https://github.com/rust-lang/rust/issues/66145
         // warning: this method call currently resolves to
         // `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions),
@@ -23,31 +24,47 @@ lazy_static! {
         // arrays are added.
         matrix![02.04159, -0.56501, -0.34473;
                 -0.96924, 01.87957, 00.04156;
-                00.01344, -0.11836, 01.01517]
-    };
-    pub(crate) static ref ADOBE_RGB_TRANSFORM_LU: PartialPivLu<f64> =
-        PartialPivLu::decompose(ADOBE_RGB_TRANSFORM.clone()).expect("Matrix is invertible.");
-    pub(crate) static ref BRADFORD_TRANSFORM: Matrix<f64> = {
+                00.01344, -0.11836, 01.01517];
+    let ADOBE_RGB_TRANSFORM_LUX: nalgebra::linalg::LU<f64, Const<3>, Const<3>> =
+        nalgebra::linalg::LU::new(ADOBE_RGB_TRANSFORMX.clone());
+}
+*/
+
+lazy_static! {
+    pub(crate) static ref ADOBE_RGB_TRANSFORM: Matrix3<f64> =
+        // FIXME: https://github.com/rust-lang/rust/issues/66145
+        // warning: this method call currently resolves to
+        // `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions),
+        // but that might change in the future when `IntoIterator` impls for
+        // arrays are added.
+        matrix![02.04159, -0.56501, -0.34473;
+                -0.96924, 01.87957, 00.04156;
+                00.01344, -0.11836, 01.01517];
+
+    pub(crate) static ref ADOBE_RGB_TRANSFORM_LU: nalgebra::linalg::LU<f64, Const<3>, Const<3>>  =
+        nalgebra::linalg::LU::new(ADOBE_RGB_TRANSFORM.clone());
+
+    pub(crate) static ref BRADFORD_TRANSFORM: Matrix3<f64> = {
         matrix![00.8951, 00.2664, -0.1614;
                 -0.7502, 01.7135, 00.0367;
                 00.0389, -0.0685, 01.0296]
     };
-    pub(crate) static ref BRADFORD_TRANSFORM_LU: PartialPivLu<f64> =
-        PartialPivLu::decompose(BRADFORD_TRANSFORM.clone()).expect("Matrix is invertible.");
-    pub(crate) static ref ROMM_RGB_TRANSFORM: Matrix<f64> = {
+    pub(crate) static ref BRADFORD_TRANSFORM_LU: nalgebra::linalg::LU<f64, Const<3>, Const<3>> =
+    nalgebra::linalg::LU::new(BRADFORD_TRANSFORM.clone());
+    pub(crate) static ref ROMM_RGB_TRANSFORM: Matrix3<f64> = {
         matrix![0.7976749, 0.1351917, 0.0313534;
                 0.2880402, 0.7118741, 0.0000857;
                 0.0000000, 0.0000000, 0.8252100]
     };
-    pub(crate) static ref ROMM_RGB_TRANSFORM_LU: PartialPivLu<f64> =
-        PartialPivLu::decompose(ROMM_RGB_TRANSFORM.clone()).expect("Matrix is invertible.");
-    pub(crate) static ref STANDARD_RGB_TRANSFORM: Matrix<f64> = {
+    pub(crate) static ref ROMM_RGB_TRANSFORM_LU: nalgebra::linalg::LU<f64, Const<3>, Const<3>> =
+    nalgebra::linalg::LU::new(ROMM_RGB_TRANSFORM.clone());
+    pub(crate) static ref STANDARD_RGB_TRANSFORM: Matrix3<f64> = {
         matrix![03.2406, -1.5372, -0.4986;
                 -0.9689, 01.8758, 00.0415;
                 00.0557, -0.2040, 01.0570]
     };
-    pub(crate) static ref STANDARD_RGB_TRANSFORM_LU: PartialPivLu<f64> =
-        PartialPivLu::decompose(STANDARD_RGB_TRANSFORM.clone()).expect("Matrix is invertible.");
+    pub(crate) static ref STANDARD_RGB_TRANSFORM_LU: nalgebra::linalg::LU<f64, Const<3>, Const<3>> =
+    nalgebra::linalg::LU::new(STANDARD_RGB_TRANSFORM.clone());
 }
 
 // These next two constants define the X11 color names and hex codes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate csv;
 extern crate geo;
 #[macro_use]
-extern crate rulinalg;
+extern crate nalgebra;
 extern crate num;
 extern crate serde;
 #[macro_use]


### PR DESCRIPTION
I removed the rulinalg dependency, which has a security vulnerability [RUSTSEC-2020-0023](https://rustsec.org/advisories/RUSTSEC-2020-0023.html) and appears to be unsupported as of today.

Had to change a couple of unit tests to fix off-by-one rounding.

This would also solve issue #46 

@nicholas-miklaucic I hope this is an acceptable, if unexpected, PR